### PR TITLE
Fix joint trajectory constraint

### DIFF
--- a/xarm_controller/config/xarm5_controllers.yaml
+++ b/xarm_controller/config/xarm5_controllers.yaml
@@ -7,7 +7,7 @@ controller_manager:
 
     xarm5_traj_controller:
       type: joint_trajectory_controller/JointTrajectoryController
-    
+
 xarm5_traj_controller:
   ros__parameters:
     command_interfaces:
@@ -25,11 +25,11 @@ xarm5_traj_controller:
     constraints:
       goal_time: 0.5
       stopped_velocity_tolerance: 0.0
-      joint1: {trajectory: 1, goal: 0.01}
-      joint2: {trajectory: 1, goal: 0.01}
-      joint3: {trajectory: 1, goal: 0.01}
-      joint4: {trajectory: 1, goal: 0.01}
-      joint5: {trajectory: 1, goal: 0.01}
+      joint1: {trajectory: 1.0, goal: 0.01}
+      joint2: {trajectory: 1.0, goal: 0.01}
+      joint3: {trajectory: 1.0, goal: 0.01}
+      joint4: {trajectory: 1.0, goal: 0.01}
+      joint5: {trajectory: 1.0, goal: 0.01}
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0

--- a/xarm_controller/config/xarm6_controllers.yaml
+++ b/xarm_controller/config/xarm6_controllers.yaml
@@ -26,12 +26,12 @@ xarm6_traj_controller:
     constraints:
       goal_time: 0.5
       stopped_velocity_tolerance: 0.0
-      joint1: {trajectory: 1, goal: 0.01}
-      joint2: {trajectory: 1, goal: 0.01}
-      joint3: {trajectory: 1, goal: 0.01}
-      joint4: {trajectory: 1, goal: 0.01}
-      joint5: {trajectory: 1, goal: 0.01}
-      joint6: {trajectory: 1, goal: 0.01}
+      joint1: {trajectory: 1.0, goal: 0.01}
+      joint2: {trajectory: 1.0, goal: 0.01}
+      joint3: {trajectory: 1.0, goal: 0.01}
+      joint4: {trajectory: 1.0, goal: 0.01}
+      joint5: {trajectory: 1.0, goal: 0.01}
+      joint6: {trajectory: 1.0, goal: 0.01}
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0

--- a/xarm_controller/config/xarm7_controllers.yaml
+++ b/xarm_controller/config/xarm7_controllers.yaml
@@ -7,7 +7,7 @@ controller_manager:
 
     xarm7_traj_controller:
       type: joint_trajectory_controller/JointTrajectoryController
-    
+
 xarm7_traj_controller:
   ros__parameters:
     command_interfaces:
@@ -27,12 +27,12 @@ xarm7_traj_controller:
     constraints:
       goal_time: 0.5
       stopped_velocity_tolerance: 0.0
-      joint1: {trajectory: 1, goal: 0.01}
-      joint2: {trajectory: 1, goal: 0.01}
-      joint3: {trajectory: 1, goal: 0.01}
-      joint4: {trajectory: 1, goal: 0.01}
-      joint5: {trajectory: 1, goal: 0.01}
-      joint6: {trajectory: 1, goal: 0.01}
+      joint1: {trajectory: 1.0, goal: 0.01}
+      joint2: {trajectory: 1.0, goal: 0.01}
+      joint3: {trajectory: 1.0, goal: 0.01}
+      joint4: {trajectory: 1.0, goal: 0.01}
+      joint5: {trajectory: 1.0, goal: 0.01}
+      joint6: {trajectory: 1.0, goal: 0.01}
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0


### PR DESCRIPTION
This PR solves the issue that appears in ros2_control when the simulation loads.

> parameter 'constraints.joint1.trajectory' has invalid type: expected [double] got [integer]

The command that I used to reproduce this was:

```bash
ros2 launch xarm_moveit_config xarm6_moveit_fake.launch.py
```

But the issue is valid for the 3 robots.

Signed-off-by: Emiliano Borghi <emiliano.borghi@gmail.com>