### PR TITLE
Fix joint_state_broadcaster controller name

### DIFF
--- a/xarm_controller/config/xarm5_controllers.yaml
+++ b/xarm_controller/config/xarm5_controllers.yaml
@@ -2,8 +2,8 @@ controller_manager:
   ros__parameters:
     update_rate: 50  # Hz
 
-    joint_state_controller:
-      type: joint_state_controller/JointStateController
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
 
     xarm5_traj_controller:
       type: joint_trajectory_controller/JointTrajectoryController

--- a/xarm_controller/config/xarm6_controllers.yaml
+++ b/xarm_controller/config/xarm6_controllers.yaml
@@ -2,8 +2,8 @@ controller_manager:
   ros__parameters:
     update_rate: 50  # Hz
 
-    joint_state_controller:
-      type: joint_state_controller/JointStateController
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
 
     xarm6_traj_controller:
       type: joint_trajectory_controller/JointTrajectoryController

--- a/xarm_controller/config/xarm7_controllers.yaml
+++ b/xarm_controller/config/xarm7_controllers.yaml
@@ -2,8 +2,8 @@ controller_manager:
   ros__parameters:
     update_rate: 50  # Hz
 
-    joint_state_controller:
-      type: joint_state_controller/JointStateController
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
 
     xarm7_traj_controller:
       type: joint_trajectory_controller/JointTrajectoryController

--- a/xarm_gazebo/launch/_dual_xarm_beside_table_gazebo.launch.py
+++ b/xarm_gazebo/launch/_dual_xarm_beside_table_gazebo.launch.py
@@ -192,7 +192,7 @@ def launch_setup(context, *args, **kwargs):
 
     # Load controllers
     controllers = [
-        'joint_state_controller',
+        'joint_state_broadcaster',
         '{}xarm{}_traj_controller'.format(prefix_1.perform(context), dof_1.perform(context)),
         '{}xarm{}_traj_controller'.format(prefix_2.perform(context), dof_2.perform(context)),
     ]

--- a/xarm_gazebo/launch/_xarm_beside_table_gazebo.launch.py
+++ b/xarm_gazebo/launch/_xarm_beside_table_gazebo.launch.py
@@ -130,7 +130,7 @@ def launch_setup(context, *args, **kwargs):
 
     # Load controllers
     controllers = [
-        'joint_state_controller',
+        'joint_state_broadcaster',
         '{}xarm{}_traj_controller'.format(prefix.perform(context), dof.perform(context)),
     ]
     if add_gripper.perform(context) in ('True', 'true'):

--- a/xarm_moveit_config/package.xml
+++ b/xarm_moveit_config/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>joint_trajectory_controller</exec_depend>
-  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/xarm_moveit_servo/launch/_xarm_moveit_servo.launch.py
+++ b/xarm_moveit_servo/launch/_xarm_moveit_servo.launch.py
@@ -100,7 +100,7 @@ def launch_setup(context, *args, **kwargs):
     xarm_traj_controller = '{}{}_traj_controller'.format(prefix.perform(context), xarm_type)
     servo_yaml['command_out_topic'] = '/{}/joint_trajectory'.format(xarm_traj_controller)
     servo_params = {"moveit_servo": servo_yaml}
-    controllers = ['joint_state_controller', xarm_traj_controller]
+    controllers = ['joint_state_broadcaster', xarm_traj_controller]
     if add_gripper.perform(context) in ('True', 'true'):
         controllers.append('{}xarm_gripper_traj_controller'.format(prefix.perform(context)))
 


### PR DESCRIPTION
`joint_state_controller` is deprecated and replaced by `joint_state_broadcaster`:
https://github.com/ros-controls/ros2_controllers/blob/79e050a05ce83896d3bd28749d4a288cfaf427bd/ros2_controllers/CHANGELOG.rst#100-2021-09-29