### PR TITLE
Fix "Attempting to load pipeline from old parameter structure. Please update your MoveIt config"

### DIFF
--- a/xarm_moveit_config/launch/_dual_robot_moveit_common.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_common.launch.py
@@ -268,13 +268,13 @@ def launch_setup(context, *args, **kwargs):
 
     # Planning Configuration
     ompl_planning_pipeline_config = {
-        'move_group': {
+        'ompl': {
             'planning_plugin': 'ompl_interface/OMPLPlanner',
             'request_adapters': """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
             'start_state_max_bounds_error': 0.1,
         }
     }
-    ompl_planning_pipeline_config['move_group'].update(ompl_planning_yaml)
+    ompl_planning_pipeline_config['ompl'].update(ompl_planning_yaml)
     # Moveit controllers Configuration
     moveit_controllers = {
         moveit_controller_manager_key.perform(context): controllers_yaml,

--- a/xarm_moveit_config/launch/_robot_moveit_common.launch.py
+++ b/xarm_moveit_config/launch/_robot_moveit_common.launch.py
@@ -135,13 +135,13 @@ def launch_setup(context, *args, **kwargs):
 
     # Planning Configuration
     ompl_planning_pipeline_config = {
-        'move_group': {
+        'ompl': {
             'planning_plugin': 'ompl_interface/OMPLPlanner',
             'request_adapters': """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
             'start_state_max_bounds_error': 0.1,
         }
     }
-    ompl_planning_pipeline_config['move_group'].update(ompl_planning_yaml)
+    ompl_planning_pipeline_config['ompl'].update(ompl_planning_yaml)
 
     # Moveit controllers Configuration
     moveit_controllers = {


### PR DESCRIPTION
Fix for the issue https://github.com/xArm-Developer/xarm_ros2/issues/35. According to the  [moveit_config package for the Franka Emika Panda](https://github.com/ros-planning/panda_moveit_config), simply changing the key value of the `ompl_planning_pipeline_config` dictionary from `move_group` to `ompl` fixed the issue.