### PR TITLE
fix upper and lower limits for lite6 joints

### DIFF
--- a/xarm_description/urdf/lite6/lite6_robot_macro.xacro
+++ b/xarm_description/urdf/lite6/lite6_robot_macro.xacro
@@ -31,20 +31,20 @@
           hw_ns="${hw_ns}" add_gripper="${add_gripper}"
           robot_ip="${robot_ip}" report_type="${report_type}"
           baud_checkset="${baud_checkset}" default_gripper_baud="${default_gripper_baud}"
-          joint1_lower_limit="${-pi*0.99}" joint1_upper_limit="${pi*0.99}"
+          joint1_lower_limit="${-2.0*pi}" joint1_upper_limit="${2.0*pi}"
           joint2_lower_limit="${-2.61799}" joint2_upper_limit="${2.61799}"
-          joint3_lower_limit="${-0.061087}" joint3_upper_limit="${pi*0.99}"
-          joint4_lower_limit="${-pi*0.99}" joint4_upper_limit="${pi*0.99}"
+          joint3_lower_limit="${-0.061087}" joint3_upper_limit="${5.235988}"
+          joint4_lower_limit="${-2.0*pi}" joint4_upper_limit="${2.0*pi}"
           joint5_lower_limit="${-2.1642}" joint5_upper_limit="${2.1642}"
-          joint6_lower_limit="${-pi*0.99}" joint6_upper_limit="${pi*0.99}"/>
+          joint6_lower_limit="${-2.0*pi}" joint6_upper_limit="${2.0*pi}"/>
       </xacro:if>
       <xacro:lite6_urdf prefix="${prefix}"
-        joint1_lower_limit="${-pi*0.99}" joint1_upper_limit="${pi*0.99}"
+        joint1_lower_limit="${-2.0*pi}" joint1_upper_limit="${2.0*pi}"
         joint2_lower_limit="${-2.61799}" joint2_upper_limit="${2.61799}"
-        joint3_lower_limit="${-0.061087}" joint3_upper_limit="${pi*0.99}"
-        joint4_lower_limit="${-pi*0.99}" joint4_upper_limit="${pi*0.99}"
+        joint3_lower_limit="${-0.061087}" joint3_upper_limit="${5.235988}"
+        joint4_lower_limit="${-2.0*pi}" joint4_upper_limit="${2.0*pi}"
         joint5_lower_limit="${-2.1642}" joint5_upper_limit="${2.1642}"
-        joint6_lower_limit="${-pi*0.99}" joint6_upper_limit="${pi*0.99}"
+        joint6_lower_limit="${-2.0*pi}" joint6_upper_limit="${2.0*pi}"
         inertial_params_filename="${inertial_params_filename}" />
     </xacro:if>
     <xacro:unless value="${limited}">


### PR DESCRIPTION
Fix the upper and lower joint limits for the lite6 according to its specs. 

For comparison see "Lite 6 Developer Manual", Table 1.1 . The document can be found here: https://www.ufactory.cc/wp-content/uploads/2023/04/Lite-6-Developer-Manual-V1.11.0.pdf