### PR TITLE
Fix tf has one or more unconnected trees 

### DIFF
--- a/xarm_moveit_config/launch/_dual_robot_moveit_common.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_common.launch.py
@@ -347,6 +347,8 @@ def launch_setup(context, *args, **kwargs):
             ('/tf_static', 'tf_static'),
         ]
     )
+    
+    target_frame = '{}{}'.format(prefix_1.perform(context), 'link_base')
 
     # Static TF
     static_tf = Node(
@@ -354,7 +356,7 @@ def launch_setup(context, *args, **kwargs):
         executable='static_transform_publisher',
         name='static_transform_publisher',
         output='screen',
-        arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'ground', 'link_base'],
+        arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', target_frame],
         parameters=[{'use_sim_time': use_sim_time}],
     )
 


### PR DESCRIPTION
Fixes error that comes up in rviz command output during startup. "ground" is not linked to "world" / not defined. Seems to by a typo for the lite6.

Implemented target_frame as variable to also make it with dual_arm configuration.