### PR TITLE
Fix robot_description_semantic publishing

### DIFF
--- a/xarm_moveit_config/launch/_robot_moveit_common.launch.py
+++ b/xarm_moveit_config/launch/_robot_moveit_common.launch.py
@@ -251,6 +251,7 @@ def launch_setup(context, *args, **kwargs):
             planning_scene_monitor_parameters,
             # sensor_manager_parameters,
             {'use_sim_time': use_sim_time},
+            {'publish_robot_description_semantic': True},
         ],
     )
 


### PR DESCRIPTION
Publishes the robot description semantic to allow for interacting with the move group interface correctly. 

Closes #81 