### PR TITLE
Fixed uri for newer Gazebo version

### DIFF
--- a/xarm_gazebo/worlds/table.world
+++ b/xarm_gazebo/worlds/table.world
@@ -2,13 +2,17 @@
 <sdf version="1.4">
   <world name="default">
     <include>
-      <uri>model://ground_plane</uri>
+      <uri>
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ground Plane
+      </uri>
     </include>
     <include>
-      <uri>model://sun</uri>
+      <uri>
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Sun
+      </uri>
     </include>
     <include>
-      <uri>model://table</uri>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Table</uri>
       <name>table</name>
       <pose>0.0 -0.84 0 0 0 0</pose>
     </include>


### PR DESCRIPTION
As pointed out in Gazebo's migration guide [here](https://gazebosim.org/docs/harmonic/migrating_gazebo_classic_ros2_packages/#edit-world-sdformat-file), the `<uri>` tag in `table.world` needs to be updated. 
Otherwise the command `ros2 launch xarm_moveit_config xarm6_moveit_gazebo.launch.py` will throw URI not found errors and won't launch Gazebo Sim. 