### PR TITLE
GZ to ROS topic bridge

### DIFF
--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
@@ -21,7 +21,7 @@
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "hardware_interface/visibility_control.h"
+// #include "hardware_interface/visibility_control.h"
 #include "controller_manager_msgs/srv/list_controllers.hpp"
 #include "controller_manager_msgs/srv/switch_controller.hpp"
 #include "xarm_api/xarm_driver.h"

--- a/xarm_gazebo/CMakeLists.txt
+++ b/xarm_gazebo/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
 install(DIRECTORY
   worlds
   launch
+  config
   DESTINATION share/${PROJECT_NAME}/
 )
 

--- a/xarm_gazebo/config/gz_bridge.yaml
+++ b/xarm_gazebo/config/gz_bridge.yaml
@@ -1,0 +1,5 @@
+- ros_topic_name: "clock"
+  gz_topic_name: "clock"
+  ros_type_name: "rosgraph_msgs/msg/Clock"
+  gz_type_name: "gz.msgs.Clock"
+  direction: GZ_TO_ROS

--- a/xarm_gazebo/launch/_robot_beside_table_gz.launch.py
+++ b/xarm_gazebo/launch/_robot_beside_table_gz.launch.py
@@ -170,6 +170,18 @@ def launch_setup(context, *args, **kwargs):
         parameters=[{'use_sim_time': True}],
     )
 
+    # bridge gz and ros topics
+    bridge_params = os.path.join(get_package_share_directory('xarm_gazebo'),'config','gz_bridge.yaml')
+    ros_gz_bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=[
+            '--ros-args',
+            '-p',
+            f'config_file:={bridge_params}'
+        ]
+    )
+
     # rviz with moveit configuration
     rviz_config_file = PathJoinSubstitution([FindPackageShare(moveit_config_package_name), 'rviz', 'planner.rviz' if no_gui_ctrl.perform(context) == 'true' else 'moveit.rviz'])
     rviz2_node = Node(
@@ -231,6 +243,12 @@ def launch_setup(context, *args, **kwargs):
                 event_handler=OnProcessStart(
                     target_action=robot_state_publisher_node,
                     on_start=gazebo_spawn_entity_node,
+                )
+            ),
+            RegisterEventHandler(
+                event_handler=OnProcessStart(
+                    target_action=robot_state_publisher_node,
+                    on_start=ros_gz_bridge,
                 )
             ),
             RegisterEventHandler(


### PR DESCRIPTION
1. Gazebo simulation (gz sim) can not communicate properly with other ros2 components like rviz and moveit because of missing clock/synchronization data.

This is the warning that shows the problem.
```
[gazebo-5] [WARN] [1737862214.636185121] [controller_manager]: No clock received, using time argument instead! Check 
your node's clock configuration (use_sim_time parameter) and if a valid clock source is available
```
Added ros to gz topic bridge node as per gazebo documentation.


2. One more change to `xarm_controller` to fix build failure caused by ros2control upstream change. Missing reference causes build failure. Reference removed based on similar action taken by this clearpath robotics package as seen here: https://github.com/clearpathrobotics/clearpath_robot/pull/115/commits/4a51281617088bb483bd9bc911d4e88cd49943f7
