### PR TITLE
Fix typo: <foramt> → <format>

### DIFF
--- a/xarm_description/urdf/camera/camera.gazebo.xacro
+++ b/xarm_description/urdf/camera/camera.gazebo.xacro
@@ -44,7 +44,7 @@
           <image>
             <width>640</width>
             <height>480</height>
-            <foramt>B8G8R8</foramt>
+            <format>B8G8R8</format>
           </image>
           <clip>
             <near>0.02</near>


### PR DESCRIPTION
Fixes a small typo in the camera Gazebo xacro.

Before:
  <foramt>B8G8R8</foramt>

After:
  <format>B8G8R8</format>

The typo causes the image format tag to be ignored by Gazebo/SDF.