### PR TITLE
Fix: make depth truly aligned-to-color and avoid far-clip “back wall”…

### DIFF
--- a/xarm_description/urdf/camera/realsense_d435i.urdf.xacro
+++ b/xarm_description/urdf/camera/realsense_d435i.urdf.xacro
@@ -58,7 +58,7 @@
       <joint name="${prefix}camera_color_joint" type="fixed">
         <parent link="${prefix}camera_link" />
         <child link="${prefix}camera_color_frame" />
-        <origin xyz="0 0.015 0" rpy="0 0 0" />
+        <origin xyz="0 0 0" rpy="0 0 0" />
       </joint>
 
       <joint name="${prefix}camera_color_optical_joint" type="fixed">


### PR DESCRIPTION
… depths

Problem:
D435i depth was visually “behind” the RGB image in RViz / PointCloud2 (depth appeared on back wall / at max range). 3D detections were offset (especially in Z), causing the arm to overshoot forward.

Root causes:
Color and depth frames had a non-zero offset (baseline), but depth was published under aligned_depth_to_color/* (pipeline assumes registered depth). Depth image topic and camera_info topic were inconsistent (image under aligned_depth_to_color, camera_info under depth/camera_info).

Fix:
Make simulated D435i depth and color originate from the same pose (so “aligned_depth_to_color” is actually aligned in simulation). Publish matching camera_info for the aligned depth topic.

Result:
Depth and RGB now align in RViz.
PointCloud2 matches the RGB features.