### PR TITLE
propagate add_gripper to xarm_planner_node

### DIFF
--- a/xarm_planner/launch/_robot_planner.launch.py
+++ b/xarm_planner/launch/_robot_planner.launch.py
@@ -119,7 +119,8 @@ def launch_setup(context, *args, **kwargs):
             {
                 'robot_type': robot_type,
                 'dof': dof,
-                'prefix': prefix
+                'prefix': prefix, 
+                'add_gripper' : add_gripper
             },
             xarm_planner_parameters,
         ],


### PR DESCRIPTION
Forward add_gripper LaunchConfiguration into xarm_planner_node parameters so the node can detect gripper configuration when launched via this launch file.