### PR TITLE
propagate add_gripper to xarm_planner_node

### DIFF
--- a/xarm_planner/launch/_dual_robot_planner.launch.py
+++ b/xarm_planner/launch/_dual_robot_planner.launch.py
@@ -185,6 +185,8 @@ def launch_setup(context, *args, **kwargs):
                 'dof_2': dof_2,
                 'prefix_1': prefix_1,
                 'prefix_2': prefix_2,
+                'add_gripper_1': add_gripper_1, 
+                'add_gripper_2': add_gripper_2
             },
             xarm_planner_parameters,
         ],


### PR DESCRIPTION
Forward add_gripper LaunchConfiguration into xarm_planner_node parameters so the node can detect gripper configuration when launched via this launch file.