### PR TITLE
[Fix[ Added extra_joints for base wheels in joint broadcaster

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -41,8 +41,7 @@ For simplified Chinese version: [简体中文版](./ReadMe_cn.md)
 - (2024-04-12) Added __uf_ros_lib__ to encapsulate certain functions for calling (including __MoveItConfigsBuilder__), see [Documentation](./uf_ros_lib/Readme.md)
 - (2024-10-11) Added [mbot_demo](demo/mbot_demo/readme.md) to demonstrate how to build a xarm robot on the chassis 
 - (2024-11-05) Support Jazzy version
-- (2024-12-02) Add detailed ReadMe instructions for xarm_api wrapped services. 
-- (2025-05-28) Add xarm_vision 
+- (2024-12-02) Add detailed ReadMe instructions for xarm_api wrapped services.  
 
 ## 3. Preparation
 
@@ -63,47 +62,44 @@ For simplified Chinese version: [简体中文版](./ReadMe_cn.md)
 - ### 4.1 Create a workspace
     ```bash
     # Skip this step if you already have a target workspace
-    cd ~
-    mkdir -p dev_ws/src
+    $ cd ~
+    $ mkdir -p dev_ws/src
     ```
 
 - ### 4.2 Obtain source code of "xarm_ros2" repository
     ```bash
     # Remember to source ros2 environment settings first
-    cd ~/dev_ws/src
+    $ cd ~/dev_ws/src
     # DO NOT omit "--recursive"，or the source code of dependent submodule will not be downloaded.
     # Pay attention to the use of the -b parameter command branch, $ROS_DISTRO indicates the currently activated ROS version, if the ROS environment is not activated, you need to customize the specified branch (foxy/galactic/humble)
-    git clone https://github.com/xArm-Developer/xarm_ros2.git --recursive -b $ROS_DISTRO
+    $ git clone https://github.com/xArm-Developer/xarm_ros2.git --recursive -b $ROS_DISTRO
     ```
 
 - ### 4.3 Update "xarm_ros2" repository 
     ```bash
-    cd ~/dev_ws/src/xarm_ros2
-
-    # If you did not use the --recursive or --recurse-submodules option when cloning, use this command to initialize and update all submodules
-    git submodule update --init --recursive
-    
-    # Pull the main repository and update the submodule
-    git pull --recurse-submodules
+    $ cd ~/dev_ws/src/xarm_ros2
+    $ git pull
+    $ git submodule sync
+    $ git submodule update --init --remote
     ```
 
 - ### 4.4 Install dependencies
     ```bash
     # Remember to source ros2 environment settings first
-    cd ~/dev_ws/src/
-    rosdep update
-    rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
+    $ cd ~/dev_ws/src/
+    $ rosdep update
+    $ rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
     ```
 
 - ### 4.5 Build xarm_ros2
     ```bash
     # Remember to source ros2 and moveit2 environment settings first
-    cd ~/dev_ws/
+    $ cd ~/dev_ws/
     # build all packages
-    colcon build
+    $ colcon build
     
     # build selected packages
-    colcon build --packages-select xarm_api
+    $ colcon build --packages-select xarm_api
     ```
 
 
@@ -118,8 +114,8 @@ __Reminder 1: If there are multiple people using ros2 in the current LAN, in ord
 __Reminder 2： Remember to source the environment setup script before running any applications in xarm_ros2__  
 
 ```bash
-cd ~/dev_ws/
-source install/setup.bash
+$ cd ~/dev_ws/
+$ source install/setup.bash
 ```
 __Reminder 3： All following instructions will base on xArm6，please use proper parameters or filenames for xArm5 or xArm7__  
 __Reminder 4: The <hw_ns> described below is replaced with the actual one, the xarm series defaults is xarm, and the rest defaults is ufactory__  
@@ -128,11 +124,11 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
 - ### 5.1 xarm_description
     This package contains robot description files and 3D models of xArm. Models can be displayed in RViz by the following launch file:
     ```bash
-    cd ~/dev_ws/
+    $ cd ~/dev_ws/
     # set 'add_gripper=true' to attach xArm gripper model
     # set 'add_vacuum_gripper=true' to attach xArm vacuum gripper model
     # Notice：Only one end_effector can be attached (set to 'true').
-    ros2 launch xarm_description xarm6_rviz_display.launch.py [add_gripper:=true] [add_vacuum_gripper:=true]
+    $ ros2 launch xarm_description xarm6_rviz_display.launch.py [add_gripper:=true] [add_vacuum_gripper:=true]
     ```
 
 - ### 5.2 xarm_msgs  
@@ -172,76 +168,76 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
     - __Launch and test (xArm)__:  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # launch xarm_driver_node
-        ros2 launch xarm_api xarm6_driver.launch.py robot_ip:=192.168.1.117
+        $ ros2 launch xarm_api xarm6_driver.launch.py robot_ip:=192.168.1.117
         # service test
-        ros2 run xarm_api test_xarm_ros_client
+        $ ros2 run xarm_api test_xarm_ros_client
         # topic test
-        ros2 run xarm_api test_robot_states
+        $ ros2 run xarm_api test_robot_states
         ```
 
     - __Use command line (xArm)__:
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # launch xarm_driver_node:
-        ros2 launch xarm_api xarm6_driver.launch.py robot_ip:=192.168.1.117
+        $ ros2 launch xarm_api xarm6_driver.launch.py robot_ip:=192.168.1.117
         
         # enable all joints:
-        ros2 service call /xarm/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
+        $ ros2 service call /xarm/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
         
         # set proper mode (0) and state (0)
-        ros2 service call /xarm/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
-        ros2 service call /xarm/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /xarm/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /xarm/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
         
         # Cartesian linear motion: (unit: mm, rad)
-        ros2 service call /xarm/set_position xarm_msgs/srv/MoveCartesian "{pose: [300, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
+        $ ros2 service call /xarm/set_position xarm_msgs/srv/MoveCartesian "{pose: [300, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
         
         # joint motion for xArm6: (unit: rad)
-        ros2 service call /xarm/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
+        $ ros2 service call /xarm/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
         ```
     
     - __Use command line (lite6)__:
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # launch ufactory_driver_node:
-        ros2 launch xarm_api lite6_driver.launch.py robot_ip:=192.168.1.161
+        $ ros2 launch xarm_api lite6_driver.launch.py robot_ip:=192.168.1.161
         
         # enable all joints:
-        ros2 service call /ufactory/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
+        $ ros2 service call /ufactory/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
         
         # set proper mode (0) and state (0)
-        ros2 service call /ufactory/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
-        ros2 service call /ufactory/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /ufactory/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /ufactory/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
         
         # Cartesian linear motion: (unit: mm, rad)
-        ros2 service call /ufactory/set_position xarm_msgs/srv/MoveCartesian "{pose: [250, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
+        $ ros2 service call /ufactory/set_position xarm_msgs/srv/MoveCartesian "{pose: [250, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
         
         # joint motion: (unit: rad)
-        ros2 service call /ufactory/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
+        $ ros2 service call /ufactory/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
         ```
     
     - __Use command line (UFACTORY850)__:
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # launch ufactory_driver_node:
-        ros2 launch xarm_api uf850_driver.launch.py robot_ip:=192.168.1.181
+        $ ros2 launch xarm_api uf850_driver.launch.py robot_ip:=192.168.1.181
         
         # enable all joints:
-        ros2 service call /ufactory/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
+        $ ros2 service call /ufactory/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
         
         # set proper mode (0) and state (0)
-        ros2 service call /ufactory/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
-        ros2 service call /ufactory/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /ufactory/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /ufactory/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
         
         # Cartesian linear motion: (unit: mm, rad)
-        ros2 service call /ufactory/set_position xarm_msgs/srv/MoveCartesian "{pose: [250, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
+        $ ros2 service call /ufactory/set_position xarm_msgs/srv/MoveCartesian "{pose: [250, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
         
         # joint motion: (unit: rad)
-        ros2 service call /ufactory/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
+        $ ros2 service call /ufactory/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
         ```
 
     Note: please study the meanings of [Mode](https://github.com/xArm-Developer/xarm_ros#6-mode-change), State and available motion instructions before testing on the real robot. Please note **the services provided by xArm series and Lite 6 have different namespaces**.  
@@ -251,15 +247,15 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
     This package defines the hardware interface for real xArm control under ros2.  
 
     ```bash
-    cd ~/dev_ws/
+    $ cd ~/dev_ws/
     # For xArm(xarm6 as example): set 'add_gripper=true' to attach xArm gripper model
-    ros2 launch xarm_controller xarm6_control_rviz_display.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
+    $ ros2 launch xarm_controller xarm6_control_rviz_display.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
 
     # For lite6: set 'add_gripper=true' to attach Lite6 gripper model
-    ros2 launch xarm_controller lite6_control_rviz_display.launch.py robot_ip:=192.168.1.161 [add_gripper:=true]
+    $ ros2 launch xarm_controller lite6_control_rviz_display.launch.py robot_ip:=192.168.1.161 [add_gripper:=true]
     
     # For UFACTORY850: set 'add_gripper=true' to attach xarm gripper model
-    ros2 launch xarm_controller uf850_control_rviz_display.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
+    $ ros2 launch xarm_controller uf850_control_rviz_display.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
     ```
 
 - ### 5.6 xarm_moveit_config
@@ -268,35 +264,35 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
     - 【simulated】Launch moveit, controlling robot in rviz.  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # For xArm(xarm6 as example): set 'add_gripper=true' to attach xArm gripper model
-        ros2 launch xarm_moveit_config xarm6_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config xarm6_moveit_fake.launch.py [add_gripper:=true]
 
         # For Lite6: set 'add_gripper=true' to attach Lite6 gripper model
-        ros2 launch xarm_moveit_config lite6_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config lite6_moveit_fake.launch.py [add_gripper:=true]
 
         # For UFACTORY850: set 'add_gripper=true' to attach xarm gripper model
-        ros2 launch xarm_moveit_config uf850_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config uf850_moveit_fake.launch.py [add_gripper:=true]
         ```
     
     - 【real arm】Launch moveit, controlling robot in rviz.  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # For xArm(xarm6 as example): set 'add_gripper=true' to attach xArm gripper model
-        ros2 launch xarm_moveit_config xarm6_moveit_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config xarm6_moveit_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
 
         # For Lite6: set 'add_gripper=true' to attach Lite6 gripper model
-        ros2 launch xarm_moveit_config lite6_moveit_realmove.launch.py robot_ip:=192.168.1.161 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config lite6_moveit_realmove.launch.py robot_ip:=192.168.1.161 [add_gripper:=true]
 
         # For UFACTORY850: set 'add_gripper=true' to attach xarm gripper model
-        ros2 launch xarm_moveit_config uf850_moveit_realmove.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config uf850_moveit_realmove.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
         ```
     
     - 【Dual simulated】Launch single moveit process, and controlling two xArms in one rviz.  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # set 'add_gripper=true' to attach xArm gripper model
         # 'add_gripper_1': can separately decide whether to attach gripper for left arm，default for same value with 'add_gripper'
         # 'add_gripper_2': can separately decide whether to attach gripper for right arm，default for same value with 'add_gripper'
@@ -304,19 +300,19 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
         # 'dof_2': can separately configure the model DOF of right arm，default to be the same DOF specified in filename.
         
         # For xArm (xarm6 here):
-        ros2 launch xarm_moveit_config dual_xarm6_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_xarm6_moveit_fake.launch.py [add_gripper:=true]
 
         # For Lite6:
-        ros2 launch xarm_moveit_config dual_lite6_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_lite6_moveit_fake.launch.py [add_gripper:=true]
 
         # For UFACTORY850:
-        ros2 launch xarm_moveit_config dual_uf850_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_uf850_moveit_fake.launch.py [add_gripper:=true]
         ```
     
     - 【Dual real arm】Launch single moveit process, and controlling two xArms in one rviz.  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 'robot_ip_1': IP address of left arm
         # 'robot_ip_2': IP address of right arm
         # set 'add_gripper=true' to attach xArm gripper model
@@ -326,51 +322,51 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
         # 'dof_2': can separately configure the model DOF of right arm，default to be the same DOF specified in filename.
         
         # For xArm (xarm6 here):
-        ros2 launch xarm_moveit_config dual_xarm6_moveit_realmove.launch.py robot_ip_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_xarm6_moveit_realmove.launch.py robot_ip_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]
         
         # For Lite6:
-        ros2 launch xarm_moveit_config dual_lite6_moveit_realmove.launch.py robot_ip_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_lite6_moveit_realmove.launch.py robot_ip_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]
 
         # For UFACTORY850:
-        ros2 launch xarm_moveit_config dual_uf850_moveit_realmove.launch.py robot_ip_1:=192.168.1.181 robot_ip_2:=192.168.1.182 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_uf850_moveit_realmove.launch.py robot_ip_1:=192.168.1.181 robot_ip_2:=192.168.1.182 [add_gripper:=true]
         ```
 
 - ### 5.7 xarm_planner
     This package provides functions for controlling xArm (simulated or real arm) through moveit API  
 
     ```bash
-    cd ~/dev_ws/
+    $ cd ~/dev_ws/
     # 【simulated xArm】launch xarm_planner_node
-    ros2 launch xarm_planner xarm6_planner_fake.launch.py [add_gripper:=true]
+    $ ros2 launch xarm_planner xarm6_planner_fake.launch.py [add_gripper:=true]
     # 【real xArm】launch xarm_planner_node
-    ros2 launch xarm_planner xarm6_planner_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
+    $ ros2 launch xarm_planner xarm6_planner_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
 
     # 【simulated Lite6】launch xarm_planner_node
-    ros2 launch xarm_planner lite6_planner_fake.launch.py [add_gripper:=true]
+    $ ros2 launch xarm_planner lite6_planner_fake.launch.py [add_gripper:=true]
     # 【real Lite6】launch xarm_planner_node
-    ros2 launch xarm_planner lite6_planner_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
+    $ ros2 launch xarm_planner lite6_planner_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
 
     # 【simulated UFACTORY850】launch xarm_planner_node
-    ros2 launch xarm_planner uf850_planner_fake.launch.py [add_gripper:=true]
+    $ ros2 launch xarm_planner uf850_planner_fake.launch.py [add_gripper:=true]
     # 【real UFACTORY850】launch xarm_planner_node
-    ros2 launch xarm_planner uf850_planner_realmove.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
+    $ ros2 launch xarm_planner uf850_planner_realmove.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
 
     # In another terminal, run test program (control through API, specify 'robot_type' as 'xarm' or 'lite' or 'uf850')
-    ros2 launch xarm_planner test_xarm_planner_api_joint.launch.py dof:=6 robot_type:=<xarm | lite | uf850>
-    ros2 launch xarm_planner test_xarm_planner_api_pose.launch.py dof:=6 robot_type:=<xarm | lite | uf850>
+    $ ros2 launch xarm_planner test_xarm_planner_api_joint.launch.py dof:=6 robot_type:=<xarm | lite | uf850>
+    $ ros2 launch xarm_planner test_xarm_planner_api_pose.launch.py dof:=6 robot_type:=<xarm | lite | uf850>
     ```
 
     Below additional tests are just for xArm:
     ```bash
     # run test program（control through service）
-    ros2 launch xarm_planner test_xarm_planner_client_joint.launch.py dof:=6
-    ros2 launch xarm_planner test_xarm_planner_client_pose.launch.py dof:=6
+    $ ros2 launch xarm_planner test_xarm_planner_client_joint.launch.py dof:=6
+    $ ros2 launch xarm_planner test_xarm_planner_client_pose.launch.py dof:=6
 
     # run test program（control gripper through API）
-    ros2 launch xarm_planner test_xarm_gripper_planner_api_joint.launch.py dof:=6
+    $ ros2 launch xarm_planner test_xarm_gripper_planner_api_joint.launch.py dof:=6
 
     # run test program（control gripper through service）
-    ros2 launch xarm_planner test_xarm_gripper_planner_client_joint.launch.py dof:=6
+    $ ros2 launch xarm_planner test_xarm_gripper_planner_client_joint.launch.py dof:=6
     ```
 
 
@@ -382,28 +378,28 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
     
     - Testing xarm on gazebo independently:
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # For xArm (xarm6 here):
-        ros2 launch xarm_gazebo xarm6_beside_table_gazebo.launch.py
+        $ ros2 launch xarm_gazebo xarm6_beside_table_gazebo.launch.py
 
         # For Lite6:
-        ros2 launch xarm_gazebo lite6_beside_table_gazebo.launch.py
+        $ ros2 launch xarm_gazebo lite6_beside_table_gazebo.launch.py
 
         # For UFACTORY850:
-        ros2 launch xarm_gazebo uf850_beside_table_gazebo.launch.py
+        $ ros2 launch xarm_gazebo uf850_beside_table_gazebo.launch.py
         ```
 
     - Simulation with moveit+gazebo (xArm controlled by moveit).
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # For xArm (xarm6 here):
-        ros2 launch xarm_moveit_config xarm6_moveit_gazebo.launch.py
+        $ ros2 launch xarm_moveit_config xarm6_moveit_gazebo.launch.py
 
         # For Lite6:
-        ros2 launch xarm_moveit_config lite6_moveit_gazebo.launch.py
+        $ ros2 launch xarm_moveit_config lite6_moveit_gazebo.launch.py
 
         # For UFACTORY850:
-        ros2 launch xarm_moveit_config uf850_moveit_gazebo.launch.py
+        $ ros2 launch xarm_moveit_config uf850_moveit_gazebo.launch.py
         ```
 - ### 5.9 xarm_moveit_servo
     This package serves as a demo for jogging xArm with devices such as joystick, through [moveit_servo](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html). 
@@ -417,23 +413,24 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
         - buttons Y and A for controlling second last joint.  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # XBOX Wired -> joystick_type=1
         # XBOX Wireless -> joystick_type=2
         # For controlling simulated xArm:
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py joystick_type:=1
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py joystick_type:=1
         # Or controlling simulated Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py joystick_type:=1
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py joystick_type:=1
         # Or controlling simulated UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py joystick_type:=1
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py joystick_type:=1
 
 
         # For controlling real xArm: (use xArm 5 as example)
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5 joystick_type:=1
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5 joystick_type:=1
         # Or controlling real Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 joystick_type:=1
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 joystick_type:=1
         # Or controlling real UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181 joystick_type:=1
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181 joystick_type:=1
+        ```
         ```
 
     - Controlling with __3Dconnexion SpaceMouse Wireless__:
@@ -442,167 +439,43 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
         - Right button clicked for just ROLL/PITCH/YAW adjustment  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # For controlling simulated xArm:
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py joystick_type:=3
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py joystick_type:=3
         # Or controlling simulated Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py joystick_type:=3
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py joystick_type:=3
         # Or controlling simulated UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py joystick_type:=3
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py joystick_type:=3
 
         # For controlling real xArm: (use xArm 5 as example)
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5 joystick_type:=3
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5 joystick_type:=3
         # Or controlling real Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 joystick_type:=3
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 joystick_type:=3
         # Or controlling real UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181 joystick_type:=3
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181 joystick_type:=3
         ```
     
     - Controlling with __PC keyboard__:
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # For controlling simulated xArm:
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py dof:=6
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py dof:=6
         # Or controlling simulated Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py
         # Or controlling simulated UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py
 
         # For controlling real xArm: (use xArm 5 as example)
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5
         # Or for controlling real Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123
         # Or for controlling real UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181
 
         # Then in another terminal, run keyboad input node:
-        ros2 run xarm_moveit_servo xarm_keyboard_input
+        $ ros2 run xarm_moveit_servo xarm_keyboard_input
         ```
         Please note that Moveit Servo may consider the home position as singularity point, then try with joint motion first.  
-
-- ### 5.10 xarm_vision
-    For simple demonstrations of vision application development with xArm, including hand-eye calibration and object detection and grasping. Examples are based on [Intel RealSense D435i](https://www.intelrealsense.com/depth-camera-d435i/) depth camera.
-
-    - #### 5.10.1 Installation of dependent packages:
-        - First enter the workspace source directory:
-            ```bash
-            cd ~/dev_ws/src/
-            ```
-        - ##### Install RealSense developer library and ROS package： 
-            Please refer to the installation steps at [official webpage](https://github.com/IntelRealSense/realsense-ros/tree/ros2-master).
-            ```bash
-            git clone -b ros2-master https://github.com/IntelRealSense/realsense-ros.git
-            ```
-
-        - ##### Install 'aruco_ros', for hand-eye calibration：
-            Refer to [official Github](https://github.com/pal-robotics/aruco_ros/tree/humble-devel):
-            ```bash
-            git clone -b humble-devel https://github.com/pal-robotics/aruco_ros.git
-            ```
-        - ##### Install 'easy_handeye2', for hand-eye calibration：
-            Refer to [official Github](https://github.com/marcoesposito1988/easy_handeye2):
-            ```bash
-            git clone https://github.com/marcoesposito1988/easy_handeye2.git
-            ``` 
-        - ##### Install 'find_object_2d', for object detection：
-            Refer to [official Github](https://github.com/introlab/find-object/tree/humble-devel):
-            ```bash
-            sudo apt-get install ros-humble-find-object-2d
-            ```
-        - ##### Install other dependencies：
-            ```bash
-            cd ~/dev_ws/src
-            rosdep update
-            rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
-            ```
-        - ##### Build the whole workspace：
-            ```bash
-            colcon build
-            ```
-
-    - #### 5.10.2 Hand-eye Calibration Demo：
-        If attaching RealSense D435i camera at tool end of xArm, with mechanical adapters, making a "**eye-on-hand**"(or eye-in-hand) configuration，the following launch file can be used and modified for hand-eye calibration: (make sure the camera communication is functional and robot is properly switched on)
-
-        ```bash 
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup d435i_robot_auto_calib.launch.py robot_type:=xarm dof:=your_xArm_DOF robot_ip:=your_xArm_IP
-        # Lite6
-        ros2 launch d435i_xarm_setup d435i_robot_auto_calib.launch.py robot_type:=lite dof:=6 robot_ip:=your_xArm_IP
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup d435i_robot_auto_calib.launch.py robot_type:=uf850 dof:=6 robot_ip:=your_xArm_IP
-        ```
-
-        Note: for xArm/UF850 produced **after August 2023**, kinematic calibration can be added to the URDF model, you can specify `kinematics_suffix` parameter for better accuracy.  
-
-        The `aruco Marker` used inside can be downloaded [here](https://chev.me/arucogen/), please remember the `marker ID` and `marker size` and modify them in the launch file accordingly. Refer to [official](https://github.com/IFL-CAMP/easy_handeye#calibration)or other usage instructions online and finish the calibration with the GUI.   
-
-        If calculation result is confirmed and saved，it will appear by default under `~/.ros2/easy_handeye2/calibrations/` directory and can be used for transferring object coordinates to base frame. If the [camera_stand](https://www.ufactory.cc/products/xarm-camera-module-2020) provided by UFACTORY is used for fixing camera, some sample calibration result are stored at `xarm_vision/d435i_xarm_setup/config/` for this case.  
-
-        ##### Precautions for Hand-eye Calibration:
-        Since `easy_handeye2` does not generate the robot arm position by default, we can control the robot arm to different positions through the xarm studio control interface or enable drag teaching after starting the above command, and then collect data through the "__Take Sample__" in the hand-eye calibration window. After collecting, the result will be automatically calculated. After collecting about 17 data, save it through "__Save__" (by default, save it in `~/.ros2/easy_handeye2/calibrations/`). It is recommended to rotate the rpy as much as possible to ensure that the calibration plate is within the field of view for the position of the robotic arm during each acquisition.
-        - The angle between the rotation axes of the two movements should be as large as possible
-        - The rotation angle corresponding to the rotation matrix of each movement should be as large as possible
-        - The distance from the camera center to the calibration plate should be as small as possible
-        - The distance moved by the end of the robot arm in each movement should be as small as possible
-
-    - #### 5.10.3 Vision Guided Grasping Demo:
-        [***find_object_2d***](http://introlab.github.io/find-object/) is used for this demo for simple object detection and grasping. Hardware used in this part: RealSense D435i depth camera, UFACTORY camera stand and the xArm Gripper(Vacuum Gripper for Lite6).  
-
-        Use moveit to drive xArm's motion，recommended for singularity and collision free execution, but will require a reliable network connection.  
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_moveit_planner.launch.py robot_type=xarm dof:=your_xArm_DOF robot_ip:=your_xArm_IP
-        # Lite6
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_moveit_planner.launch.py robot_type=lite dof:=6 robot_ip:=your_xArm_IP
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_moveit_planner.launch.py robot_type=uf850 dof:=6 robot_ip:=your_xArm_IP
-
-        # The default calibration parameters are ~/.ros2/easy_handeye2/calibrations/{robot_type}_rs_on_hand_calibration.calib
-        # If you need to specify the startup parameter calib_filename, the calibration parameters recorded in the d435i_xarm_setup/config/{calib_filename}.calib file will be used
-        ```
-        If target object can be properly detected, to run the Grasping node:  
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup grasp_node_robot_moveit_planner.launch.py robot_type:=xarm dof:=your_xArm_DOF
-        # Lite6
-        ros2 launch d435i_xarm_setup grasp_node_robot_moveit_planner.launch.py robot_type:=lite dof:=6
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup grasp_node_robot_moveit_planner.launch.py robot_type:=uf850 dof:=6
-        ```
-        For node program source code, refer to: d435i_xarm_setup/src/[findobj_grasp_moveit_planner.cpp](./xarm_vision/d435i_xarm_setup/src/findobj_grasp_moveit_planner.cpp).  
-
-        2.Alternatively, to drive xArm motion with ros service provided by 'xarm_api', in this way, real-time performance of network will not be required so strict as moveit way, but execution may fail in the middle if singularity or self-collision is about to occur. 
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_api.launch.py robot_type:=xarm dof:=your_xArm_DOF robot_ip:=your_xArm_IP
-        # Lite6
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_api.launch.py robot_type:=lite dof:=6 robot_ip:=your_xArm_IP
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_api.launch.py robot_type:=uf850 dof:=6 robot_ip:=your_xArm_IP
-
-        # The default calibration parameters are ~/.ros2/easy_handeye2/calibrations/{robot_type}_rs_on_hand_calibration.calib
-        # If you need to specify the startup parameter calib_filename, the calibration parameters recorded in the d435i_xarm_setup/config/{calib_filename}.calib file will be used
-        ```
-        If target object can be properly detected, to run the Grasping node:  
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup grasp_node_robot_api.launch.py robot_type:=xarm dof:=your_xArm_DOF
-        # Lite6
-        ros2 launch d435i_xarm_setup grasp_node_robot_api.launch.py robot_type:=lite dof:=6
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup grasp_node_robot_api.launch.py robot_type:=uf850 dof:=6
-        ```
-        For node program source code, refer to: d435i_xarm_setup/src/[findobj_grasp_xarm_api.cpp](./xarm_vision/d435i_xarm_setup/src/findobj_grasp_xarm_api.cpp).  
-
-        ***Please read and comprehend the source code and make necessary modifications before real application test***, necessary modifications include preparation pose, grasping orientation, grasping depth, motion speed and so on. The identification target name in the code is "object_1", which corresponds to `1.png` in /objects directory, users can add their own target in "find_object_2d" GUI, then modify the `source_frame` inside the code, for costomized application.  
-
-        ***Tips***: make sure the background is clean and the color is distinguished from the object, detection success rate can be higher if the target object has rich texture (features).
-
-    - #### 5.10.4 Adding RealSense D435i model to simulated xArm：
-        For installation with camera stand provided by UFACTORY, the cam model can be attached by following modifications (use xarm7 as example):    
-        ```bash
-        ros2 launch xarm_moveit_config xarm7_moveit_fake.launch add_realsense_d435i:=true
-        ```
 
 ## 6. Instruction on major launch arguments
 - __robot_ip__,
@@ -664,7 +537,7 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
     - __Example of adding customized end tool (Cylinder):__  
 
         ```bash
-        ros2 launch xarm_gazebo xarm6_beside_table_gazebo.launch.py add_other_geometry:=true geometry_type:=cylinder geometry_height:=0.075 geometry_radius:=0.045
+        $ ros2 launch xarm_gazebo xarm6_beside_table_gazebo.launch.py add_other_geometry:=true geometry_type:=cylinder geometry_height:=0.075 geometry_radius:=0.045
         ```
 
     For dual arm launch files(with ```dual_``` prefix), here are the total arguments that can be configured:  

--- a/ReadMe_cn.md
+++ b/ReadMe_cn.md
@@ -41,7 +41,6 @@
 - (2024-10-11) 增加[mbot_demo](demo/mbot_demo/readme.md)演示如何建立xarm机械臂在底盘之上
 - (2024-11-05) 支持Ros Jazzy版本
 - (2024-12-02) 新增xarm_api封装的sdk服务的详细使用说明  
-- (2025-05-28) 新增xarm_vision
 
 ## 3. 准备工作
 
@@ -62,47 +61,44 @@
 - ### 4.1 创建工作区
     ```bash
     # 如果已经有自己工作区，请跳过这一步骤
-    cd ~
-    mkdir -p dev_ws/src
+    $ cd ~
+    $ mkdir -p dev_ws/src
     ```
 
 - ### 4.2 获取xarm_ros2源码包
     ```bash
     # 记得先source已安装的ros2环境
-    cd ~/dev_ws/src
+    $ cd ~/dev_ws/src
     # 注意需要--recursive参数，否则不会下载源码包的子模块源码
     # 注意使用-b参数指令分支, $ROS_DISTRO表示当前激活的ROS版本，如果没有激活ROS环境，需要自定指定分支(foxy/galactic/humble)
-    git clone https://github.com/xArm-Developer/xarm_ros2.git --recursive -b $ROS_DISTRO
+    $ git clone https://github.com/xArm-Developer/xarm_ros2.git --recursive -b $ROS_DISTRO
     ```
 
 - ### 4.3 升级xarm_ros2源码包
     ```bash
-    cd ~/dev_ws/src/xarm_ros2
-
-    # 如果克隆时没有使用--recursive或--recurse-submodules参数, 使用该命令来初始化并更新所有子模块
-    git submodule update --init --recursive
-    
-    # 拉取（Pull）主仓库并更新子模块
-    git pull --recurse-submodules
+    $ cd ~/dev_ws/src/xarm_ros2
+    $ git pull
+    $ git submodule sync
+    $ git submodule update --init --remote
     ```
 
 - ### 4.4 安装xarm_ros2依赖
     ```bash
     # 记得先source已安装的ros2环境
-    cd ~/dev_ws/src/
-    rosdep update
-    rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
+    $ cd ~/dev_ws/src/
+    $ rosdep update
+    $ rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
     ```
 
 - ### 4.5 编译xarm_ros2
     ```bash
     # 记得先source已安装的ros2环境和moveit2环境
-    cd ~/dev_ws/
+    $ cd ~/dev_ws/
     # 编译所有包
-    colcon build
+    $ colcon build
     
     # 编译单个包
-    colcon build --packages-select xarm_api
+    $ colcon build --packages-select xarm_api
     ```
 
 
@@ -115,8 +111,8 @@ __注意1： 如果当前局域网有多人使用ros2，为避免相互间发生
 
 __注意2： 运行xarm_ros2中的程序或启动脚本之前请先source当前工作区环境__  
 ```bash
-cd ~/dev_ws/
-source install/setup.bash
+$ cd ~/dev_ws/
+$ source install/setup.bash
 ```
 __注意3： 以下启动说明以6轴为例，5轴和7轴的用法只需找到对应的启动文件或指定对应的参数__  
 __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, 其余的默认为ufactory__  
@@ -124,11 +120,11 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
 - ### 5.1 xarm_description
     此模块包含机械臂的描述文件，通过以下启动脚本可以在rviz中显示对应的机械臂模型
     ```bash
-    cd ~/dev_ws/
+    $ cd ~/dev_ws/
     # add_gripper为true时会加载xarm夹爪的模型
     # add_vacuum_gripper为true时会加载xarm真空吸头的模型
     # 注意：只能加载一款末端器件
-    ros2 launch xarm_description xarm6_rviz_display.launch.py [add_gripper:=true] [add_vacuum_gripper:=true]
+    $ ros2 launch xarm_description xarm6_rviz_display.launch.py [add_gripper:=true] [add_vacuum_gripper:=true]
     ```
 
 - ### 5.2 xarm_msgs
@@ -168,74 +164,74 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
     
     - __启动与测试（xArm）__:
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 启动xarm_driver_node
-        ros2 launch xarm_api xarm6_driver.launch.py robot_ip:=192.168.1.117
+        $ ros2 launch xarm_api xarm6_driver.launch.py robot_ip:=192.168.1.117
         # 测试service
-        ros2 run xarm_api test_xarm_ros_client
+        $ ros2 run xarm_api test_xarm_ros_client
         # 测试topic
-        ros2 run xarm_api test_robot_states
+        $ ros2 run xarm_api test_robot_states
         ```
     - __使用命令行（xArm）__:
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 启动 xarm_driver_node
-        ros2 launch xarm_api xarm6_driver.launch.py robot_ip:=192.168.1.117
+        $ ros2 launch xarm_api xarm6_driver.launch.py robot_ip:=192.168.1.117
         
         # 使能所有关节:
-        ros2 service call /xarm/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
+        $ ros2 service call /xarm/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
         
         # 设置适当的模式 (0) 和状态 (0)
-        ros2 service call /xarm/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
-        ros2 service call /xarm/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /xarm/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /xarm/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
         
         # 笛卡尔直线运动: (单位: mm, rad)
-        ros2 service call /xarm/set_position xarm_msgs/srv/MoveCartesian "{pose: [300, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
+        $ ros2 service call /xarm/set_position xarm_msgs/srv/MoveCartesian "{pose: [300, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
         
         # 关节运动 适用xArm6: (单位: rad)
-        ros2 service call /xarm/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
+        $ ros2 service call /xarm/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
         ```
     - __使用命令行（lite6）__:
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 启动 ufactory_driver_node
-        ros2 launch xarm_api lite6_driver.launch.py robot_ip:=192.168.1.161
+        $ ros2 launch xarm_api lite6_driver.launch.py robot_ip:=192.168.1.161
         
         # 使能所有关节:
-        ros2 service call /ufactory/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
+        $ ros2 service call /ufactory/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
         
         # 设置适当的模式 (0) 和状态 (0)
-        ros2 service call /ufactory/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
-        ros2 service call /ufactory/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /ufactory/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /ufactory/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
         
         # 笛卡尔直线运动: (单位: mm, rad)
-        ros2 service call /ufactory/set_position xarm_msgs/srv/MoveCartesian "{pose: [250, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
+        $ ros2 service call /ufactory/set_position xarm_msgs/srv/MoveCartesian "{pose: [250, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
         
         # 关节运动: (单位: rad)
-        ros2 service call /ufactory/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
+        $ ros2 service call /ufactory/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
         ```
     
     - __使用命令行（UFACTORY850）__:
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 启动 ufactory_driver_node
-        ros2 launch xarm_api uf850_driver.launch.py robot_ip:=192.168.1.181
+        $ ros2 launch xarm_api uf850_driver.launch.py robot_ip:=192.168.1.181
         
         # 使能所有关节:
-        ros2 service call /ufactory/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
+        $ ros2 service call /ufactory/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
         
         # 设置适当的模式 (0) 和状态 (0)
-        ros2 service call /ufactory/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
-        ros2 service call /ufactory/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /ufactory/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
+        $ ros2 service call /ufactory/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
         
         # 笛卡尔直线运动: (单位: mm, rad)
-        ros2 service call /ufactory/set_position xarm_msgs/srv/MoveCartesian "{pose: [250, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
+        $ ros2 service call /ufactory/set_position xarm_msgs/srv/MoveCartesian "{pose: [250, 0, 250, 3.14, 0, 0], speed: 50, acc: 500, mvtime: 0}"   
         
         # 关节运动: (单位: rad)
-        ros2 service call /ufactory/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
+        $ ros2 service call /ufactory/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.58, 0, 0, 0, 0, 0], speed: 0.35, acc: 10, mvtime: 0}"
         ```
 
     注: 请在使用真机测试之前仔细研究[Mode](https://github.com/xArm-Developer/xarm_ros#6-mode-change), State和可用运动指令的含义。注意**Lite 6与xArm系列提供的服务所在的命名空间不同**。  
@@ -244,15 +240,15 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
 - ### 5.5 xarm_controller
     此模块是ros2_control和机械臂通信的硬件接口模块
     ```bash
-    cd ~/dev_ws/
+    $ cd ~/dev_ws/
     # 对于xArm系列(xarm6举例)：add_gripper为true时会加载xarm夹爪的模型
-    ros2 launch xarm_controller xarm6_control_rviz_display.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
+    $ ros2 launch xarm_controller xarm6_control_rviz_display.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
 
     # 对于lite 6: add_gripper为true时会加载Lite夹爪的模型
-    ros2 launch xarm_controller lite6_control_rviz_display.launch.py robot_ip:=192.168.1.161 [add_gripper:=true]
+    $ ros2 launch xarm_controller lite6_control_rviz_display.launch.py robot_ip:=192.168.1.161 [add_gripper:=true]
 
     # 对于UFACTORY850: add_gripper为true时会加载xarm夹爪的模型
-    ros2 launch xarm_controller uf850_control_rviz_display.launch.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
+    $ ros2 launch xarm_controller uf850_control_rviz_display.launch.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
     ```
 
 - ### 5.6 xarm_moveit_config
@@ -261,35 +257,35 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
     - 【虚拟】启动moveit并在rviz显示, 控制机械臂  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 对于xArm系列(xarm6举例)：add_gripper为true时会加载xarm夹爪的模型
-        ros2 launch xarm_moveit_config xarm6_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config xarm6_moveit_fake.launch.py [add_gripper:=true]
 
         # 对于lite 6: add_gripper为true时会加载Lite夹爪的模型
-        ros2 launch xarm_moveit_config lite6_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config lite6_moveit_fake.launch.py [add_gripper:=true]
 
         # 对于UFACTORY850: add_gripper为true时会加载xarm夹爪的模型
-        ros2 launch xarm_moveit_config uf850_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config uf850_moveit_fake.launch.py [add_gripper:=true]
         ```
     
     - 【真机】启动moveit并在rviz显示, 控制机械臂  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 对于xArm系列(xarm6举例)：add_gripper为true时会加载xarm夹爪的模型
-        ros2 launch xarm_moveit_config xarm6_moveit_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config xarm6_moveit_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
 
         # 对于lite 6: add_gripper为true时会加载Lite夹爪的模型
-        ros2 launch xarm_moveit_config lite6_moveit_realmove.launch.py robot_ip:=192.168.1.161 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config lite6_moveit_realmove.launch.py robot_ip:=192.168.1.161 [add_gripper:=true]
 
         # 对于UFACTORY850: add_gripper为true时会加载xarm夹爪的模型
-        ros2 launch xarm_moveit_config uf850_moveit_realmove.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config uf850_moveit_realmove.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
         ```
     
     - 【Dual虚拟】启动moveit并在rviz显示, 控制两台机械臂  
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # add_gripper为true时会加载xarm夹爪的模型
         # add_gripper_1参数可以单独指定左臂是否加载夹爪的模型，默认为add_gripper的值
         # add_gripper_2参数可以单独指定右臂是否加载夹爪的模型，默认为add_gripper的值
@@ -297,19 +293,19 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
         # dof_2参数可以单独指定右臂轴数，默认为dof的值（这里为6，不同启动脚本不一样）
 
         # 对于xArm系列（xarm6）：
-        ros2 launch xarm_moveit_config dual_xarm6_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_xarm6_moveit_fake.launch.py [add_gripper:=true]
         
         # 对于Lite6：
-        ros2 launch xarm_moveit_config dual_lite6_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_lite6_moveit_fake.launch.py [add_gripper:=true]
 
         # 对于UFACTORY850：
-        ros2 launch xarm_moveit_config dual_uf850_moveit_fake.launch.py [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_uf850_moveit_fake.launch.py [add_gripper:=true]
         ```
     
     - 【Dual真机】启动moveit并在rviz显示, 控制两台机械臂   
     
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # robot_ip_1表示左臂控制的IP地址
         # robot_ip_2表示右臂控制的IP地址
         # add_gripper为true时会加载xarm夹爪的模型
@@ -319,49 +315,49 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
         # dof_2参数可以单独指定右臂轴数，默认为dof的值（这里为6，不同启动脚本不一样）
         
         # 对于xArm系列（xarm6）：
-        ros2 launch xarm_moveit_config dual_xarm6_moveit_realmove.launch.py robot_ip_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_xarm6_moveit_realmove.launch.py robot_ip_1_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]
 
         # 对于Lite6：
-        ros2 launch xarm_moveit_config dual_lite6_moveit_realmove.launch.py robot_ip_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_lite6_moveit_realmove.launch.py robot_ip_1_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]
 
         # 对于UFACTORY850：
-        ros2 launch xarm_moveit_config dual_uf850_moveit_realmove.launch.py robot_ip_1:=192.168.1.181 robot_ip_2:=192.168.1.182 [add_gripper:=true]
+        $ ros2 launch xarm_moveit_config dual_uf850_moveit_realmove.launch.py robot_ip_1_1:=192.168.1.181 robot_ip_2:=192.168.1.182 [add_gripper:=true]
         ```
 
 - ### 5.7 xarm_planner
     此模块提供了通过moveit API控制机械臂
     ```bash
-    cd ~/dev_ws/
+    $ cd ~/dev_ws/
     # 【虚拟xArm】启动xarm_planner_node
-    ros2 launch xarm_planner xarm6_planner_fake.launch.py [add_gripper:=true]
+    $ ros2 launch xarm_planner xarm6_planner_fake.launch.py [add_gripper:=true]
     # 【xArm真机】启动xarm_planner_node
-    ros2 launch xarm_planner xarm6_planner_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
+    $ ros2 launch xarm_planner xarm6_planner_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
 
     # 【虚拟lite6】启动xarm_planner_node
-    ros2 launch xarm_planner lite6_planner_fake.launch.py [add_gripper:=true]
+    $ ros2 launch xarm_planner lite6_planner_fake.launch.py [add_gripper:=true]
     # 【lite6真机】启动xarm_planner_node
-    ros2 launch xarm_planner lite6_planner_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
+    $ ros2 launch xarm_planner lite6_planner_realmove.launch.py robot_ip:=192.168.1.117 [add_gripper:=true]
 
     # 【虚拟UFACTORY850】启动xarm_planner_node
-    ros2 launch xarm_planner uf850_planner_fake.launch.py [add_gripper:=true]
+    $ ros2 launch xarm_planner uf850_planner_fake.launch.py [add_gripper:=true]
     # 【UFACTORY850真机】启动xarm_planner_node
-    ros2 launch xarm_planner uf850_planner_realmove.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
+    $ ros2 launch xarm_planner uf850_planner_realmove.launch.py robot_ip:=192.168.1.181 [add_gripper:=true]
     
     # 运行测试(通过API控制, 根据系列型号指定robot_type为xarm或lite或uf850)
-    ros2 launch xarm_planner test_xarm_planner_api_joint.launch.py dof:=6 robot_type:=<xarm | lite | uf850>
-    ros2 launch xarm_planner test_xarm_planner_api_pose.launch.py dof:=6 robot_type:=<xarm | lite | uf850>
+    $ ros2 launch xarm_planner test_xarm_planner_api_joint.launch.py dof:=6 robot_type:=<xarm | lite | uf850>
+    $ ros2 launch xarm_planner test_xarm_planner_api_pose.launch.py dof:=6 robot_type:=<xarm | lite | uf850>
     ```
     以下这些测试目前仅适用于xArm:
     ```bash
     # 运行测试（通过service控制）
-    ros2 launch xarm_planner test_xarm_planner_client_joint.launch.py dof:=6
-    ros2 launch xarm_planner test_xarm_planner_client_pose.launch.py dof:=6
+    $ ros2 launch xarm_planner test_xarm_planner_client_joint.launch.py dof:=6
+    $ ros2 launch xarm_planner test_xarm_planner_client_pose.launch.py dof:=6
 
     # 运行测试（通过API控制机械爪）
-    ros2 launch xarm_planner test_xarm_gripper_planner_api_joint.launch.py dof:=6
+    $ ros2 launch xarm_planner test_xarm_gripper_planner_api_joint.launch.py dof:=6
 
     # 运行测试（通过service控制机械爪）
-    ros2 launch xarm_planner test_xarm_gripper_planner_client_joint.launch.py dof:=6
+    $ ros2 launch xarm_planner test_xarm_gripper_planner_client_joint.launch.py dof:=6
     ```
 
 - ### 5.8 xarm_gazebo
@@ -372,28 +368,28 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
     
     - 单独测试xarm在gazebo上的显示：
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 对于xArm系列（xarm6）：
-        ros2 launch xarm_gazebo xarm6_beside_table_gazebo.launch.py
+        $ ros2 launch xarm_gazebo xarm6_beside_table_gazebo.launch.py
 
         # 对于Lite6：
-        ros2 launch xarm_gazebo lite6_beside_table_gazebo.launch.py
+        $ ros2 launch xarm_gazebo lite6_beside_table_gazebo.launch.py
 
         # 对于UFACTORY850：
-        ros2 launch xarm_gazebo uf850_beside_table_gazebo.launch.py
+        $ ros2 launch xarm_gazebo uf850_beside_table_gazebo.launch.py
         ```
 
     - 联合moveit+gazebo进行控制：
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 对于xArm系列（xarm6）：
-        ros2 launch xarm_moveit_config xarm6_moveit_gazebo.launch.py
+        $ ros2 launch xarm_moveit_config xarm6_moveit_gazebo.launch.py
 
         # 对于Lite6：
-        ros2 launch xarm_moveit_config lite6_moveit_gazebo.launch.py
+        $ ros2 launch xarm_moveit_config lite6_moveit_gazebo.launch.py
 
         # 对于UFACTORY850：
-        ros2 launch xarm_moveit_config uf850_moveit_gazebo.launch.py
+        $ ros2 launch xarm_moveit_config uf850_moveit_gazebo.launch.py
         ```
 
 - ### 5.9 xarm_moveit_servo
@@ -408,23 +404,23 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
         - 按键Y和按键A控制倒数第二个关节的转动
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # XBOX Wired -> joystick_type=1
         # XBOX Wireless -> joystick_type=2
 
         # 控制虚拟xArm6机械臂
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py joystick_type:=1
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py joystick_type:=1
         # 或者控制虚拟Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py joystick_type:=1
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py joystick_type:=1
         # 或者控制虚拟UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py joystick_type:=1
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py joystick_type:=1
 
         # 控制真实xArm5机械臂
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5 joystick_type:=1
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5 joystick_type:=1
         # 或者控制真实Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 joystick_type:=1
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 joystick_type:=1
         # 或者控制真实UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181 joystick_type:=1
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181 joystick_type:=1
         ```
 
     - 通过六维鼠标 __3Dconnexion SpaceMouse Wireless__ 来控制
@@ -433,160 +429,40 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
         - 右边按键按下时单独控制TCP的ROLL/PITCH/YAW
 
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 控制虚拟xArm6机械臂
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py joystick_type:=3
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py joystick_type:=3
         # 或者控制虚拟Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py joystick_type:=3
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py joystick_type:=3
         # 或者控制虚拟UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py joystick_type:=3
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py joystick_type:=3
 
         # 控制真实xArm5机械臂
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5 joystick_type:=3
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5 joystick_type:=3
         # 或者控制真实Lite6:
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=6 robot_type:=lite joystick_type:=3
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=6 robot_type:=lite joystick_type:=3
         # 或者控制真实UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181 joystick_type:=3
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181 joystick_type:=3
         ```
     - 通过 __键盘输入__ 控制
         ```bash
-        cd ~/dev_ws/
+        $ cd ~/dev_ws/
         # 控制虚拟xArm6机械臂
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_fake.launch.py
         # 或者控制虚拟Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_fake.launch.py
         # 或者控制虚拟UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_fake.launch.py
 
         # 控制真实xArm5机械臂
-        ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5
+        $ ros2 launch xarm_moveit_servo xarm_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123 dof:=5
         # 或者控制真实Lite6:
-        ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123
+        $ ros2 launch xarm_moveit_servo lite6_moveit_servo_realmove.launch.py robot_ip:=192.168.1.123
         # 或者控制真实UFACTORY850:
-        ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181
+        $ ros2 launch xarm_moveit_servo uf850_moveit_servo_realmove.launch.py robot_ip:=192.168.1.181
 
         # 之后在另一个终端，运行键盘输入响应节点
-        ros2 run xarm_moveit_servo xarm_keyboard_input
-        ```
-- ### 5.10 xarm_vision
-    提供xArm扩展视觉应用的基础示例，包括手眼标定和视觉抓取，例程主要基于[Intel RealSense D435i](https://www.intelrealsense.com/depth-camera-d435i/)深度相机。 
-
-    - #### 5.10.1 相关依赖库和ros包的安装：
-        - 首先进入ros工作空间：
-            ```bash
-            cd ~/dev_ws/src/
-            ```
-
-        - ##### 安装RealSense 开发支持库和ROS软件包： 
-            请依照[官方指示步骤](https://github.com/IntelRealSense/realsense-ros/tree/ros2-master)正确安装。
-            ```bash
-            git clone -b ros2-master https://github.com/IntelRealSense/realsense-ros.git
-            ```
-
-        - ##### 安装aruco_ros, 用于手眼标定：
-            参考[官方Github](https://github.com/pal-robotics/aruco_ros/tree/humble-devel):
-            ```bash
-            git clone -b humble-devel https://github.com/pal-robotics/aruco_ros.git
-            ```
-        - ##### 安装easy_handeye2, 用于手眼标定：
-            参考[官方Github](https://github.com/marcoesposito1988/easy_handeye2):
-            ```bash
-            git clone https://github.com/marcoesposito1988/easy_handeye2.git
-            ``` 
-        - ##### 安装find_object_2d包，用于物体识别：
-            参考[官方Github](https://github.com/introlab/find-object/tree/humble-devel):
-            ```bash
-            sudo apt-get install ros-humble-find-object-2d
-            ```
-        - ##### 安装其他依赖包：
-            ```bash
-            cd ~/dev_ws/src
-            rosdep update
-            rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
-            ```
-        - ##### 编译整个工作区：
-            ```bash
-            colcon build
-            ```
-
-    - #### 5.10.2 手眼标定示例：
-        如果使用RealSense D435i相机配合固定工件安装在手臂末端，即“**眼在手上**”，确保相机与电脑通信正常且手臂正常上电后，可以参考和使用如下launch脚本进行手眼标定：
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup d435i_robot_auto_calib.launch.py robot_type:=xarm dof:=your_xArm_DOF robot_ip:=your_xArm_IP
-        # Lite6
-        ros2 launch d435i_xarm_setup d435i_robot_auto_calib.launch.py robot_type:=lite dof:=6 robot_ip:=your_xArm_IP
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup d435i_robot_auto_calib.launch.py robot_type:=uf850 dof:=6 robot_ip:=your_xArm_IP
-        ```
-        注意: 对于**2023年8月之后**生产的xArm/UF850系列型号, 可以选择将运动学校准参数加入到URDF模型中, 在以上的launch命令中使用`kinematics_suffix`参数来提高标定的准确度。   
-
-        标定使用的aruco二维码可以在[这里下载](https://chev.me/arucogen/)，请记住自己下载的`marker ID`和`marker size`，并在以上launch文件中修改。参考[官方](https://github.com/IFL-CAMP/easy_handeye#calibration)或其他网络教程通过图形界面进行标定，标定完成并确认保存后，默认会在 `~/.ros2/easy_handeye2/calibrations/`目录下生成`.calib`后缀的结果文档，供后续与手臂一起进行坐标变换使用。如果固定件用的是UFACTORY提供的[camera_stand](https://www.ufactory.cc/products/xarm-camera-module-2020)，在`xarm_vision/d435i_xarm_setup/config/`目录中保存了参考的标定结果。 
-
-        ##### 手眼标定注意事项:
-        由于`easy_handeye2`默认不生成机械臂位置，我们可以在上述命令启动后，通过xarm studio控制界面或者开启拖动示教认为控制机械臂到不同位置，然后通过启动的手眼标定窗口的"__Take Sample__"采集数据，采集后会自动计算结果，采集到大概17个数据后通过"__Save__"保存(默认保存在`~/.ros2/easy_handeye2/calibrations/`)，每次采集时机械臂的位置建议在保证标定板在视野范围内尽量多旋转rpy
-        - 两次运动的旋转轴的夹角越大越好
-        - 每次运动的旋转矩阵对应的旋转角度越大越好
-        - 相机中心到标定板的距离越小越好
-        - 每次运动机械臂末端运动的距离越小越好
-
-    - #### 5.10.3 3D视觉抓取示例：
-        本部分提供利用[***find_object_2d***](http://introlab.github.io/find-object/)进行简单的物体识别和抓取的示例程序。使用了RealSense D435i深度相机，UFACTORY camera_stand以及xArm官方机械爪(__Lite6用的是吸头__)。  
-
-        1.使用moveit驱动手臂动作，如果规划成功会保证无碰撞和奇异点的轨迹执行, 但对网络通信稳定性要求较高：
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_moveit_planner.launch.py robot_type:=xarm dof:=your_xArm_DOF robot_ip:=your_xArm_IP
-        # Lite6
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_moveit_planner.launch.py robot_type:=lite dof:=6 robot_ip:=your_xArm_IP
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_moveit_planner.launch.py robot_type:=uf850 dof:=6 robot_ip:=your_xArm_IP
-
-        # 默认使用的标定参数是~/.ros2/easy_handeye2/calibrations/{robot_type}_rs_on_hand_calibration.calib
-        # 如果需要指定启动参数calib_filename, 将使用d435i_xarm_setup/config/{calib_filename}.calib文件记录的标定参数
-        ```
-        如果目标物体可以正常识别，执行抓取节点:  
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup grasp_node_robot_moveit_planner.launch.py robot_type:=xarm dof:=your_xArm_DOF
-        # Lite6
-        ros2 launch d435i_xarm_setup grasp_node_robot_moveit_planner.launch.py robot_type:=lite dof:=6
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup grasp_node_robot_moveit_planner.launch.py robot_type:=uf850 dof:=6
-        ```
-        节点代码可以参考d435i_xarm_setup/src/[findobj_grasp_moveit_planner.cpp](./xarm_vision/d435i_xarm_setup/src/findobj_grasp_moveit_planner.cpp).  
-
-        2.或者使用xarm_api提供的ros service驱动手臂动作，网络稳定性要求不高，但部分时候执行过程中可能报错（奇异点或将要发生自碰撞等）：
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_api.launch.py robot_type:=xarm dof:=your_xArm_DOF robot_ip:=your_xArm_IP
-        # Lite6
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_api.launch.py robot_type:=lite dof:=6 robot_ip:=your_xArm_IP
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup d435i_findobj2d_robot_api.launch.py robot_type:=uf850 dof:=6 robot_ip:=your_xArm_IP
-
-        # 默认使用的标定参数是~/.ros2/easy_handeye2/calibrations/{robot_type}_rs_on_hand_calibration.calib
-        # 如果需要指定启动参数calib_filename, 将使用d435i_xarm_setup/config/{calib_filename}.calib文件记录的标定参数
-        ```
-        如果目标物体可以正常识别，执行抓取节点:  
-        ```bash
-        # xArm 5/6/7
-        ros2 launch d435i_xarm_setup grasp_node_robot_api.launch.py robot_type:=xarm dof:=your_xArm_DOF
-        # Lite6
-        ros2 launch d435i_xarm_setup grasp_node_robot_api.launch.py robot_type:=lite dof:=6
-        # UFACTORY850
-        ros2 launch d435i_xarm_setup grasp_node_robot_api.launch.py robot_type:=uf850 dof:=6
-        ``` 
-        节点代码可以参考d435i_xarm_setup/src/[findobj_grasp_xarm_api.cpp](./xarm_vision/d435i_xarm_setup/src/findobj_grasp_xarm_api.cpp).
-
-        ***实际应用之前，请先读懂对应的代码，并针对自己的场景做出必要的修改***，比如抓取准备位置，姿态，抓取深度以及移动速度等等。代码中使用的识别目标名称为“object_1”，对应/objects目录下的`1.png`，用户可以根据实际应用在find_object_2d的图形界面中添加新的目标并修改节点程序中的`source_frame`，来识别感兴趣的物体。  
-
-        ***Tips***: 应注意背景尽量干净而且颜色与被识别物体有区分度，如果目标物体有比较丰富的文理，识别率会更高。
-
-    - #### 7.4 在仿真的xArm模型末端添加RealSense D435i模型：
-        如果使用UFACTORY提供的camera stand固定，可以通过以下设置添加到虚拟模型（以xarm7为例）：  
-        ```bash
-        ros2 launch xarm_moveit_config xarm7_moveit_fake.launch add_realsense_d435i:=true
+        $ ros2 run xarm_moveit_servo xarm_keyboard_input
         ```
 
 
@@ -650,7 +526,7 @@ __注意4: 以下描述的<hw_ns>用实际的替换，xarm系列默认为xarm, �
     - __添加自定义末端工具(圆柱体)示例__  
     
         ```bash
-        ros2 launch xarm_gazebo xarm6_beside_table_gazebo.launch.py add_other_geometry:=true geometry_type:=cylinder geometry_height:=0.075 geometry_radius:=0.045
+        $ ros2 launch xarm_gazebo xarm6_beside_table_gazebo.launch.py add_other_geometry:=true geometry_type:=cylinder geometry_height:=0.075 geometry_radius:=0.045
         ```
 
     对于双臂启动脚本(dual_开头的)，可以通过以下参数分别指定:

--- a/demo/mbot_demo/package.xml
+++ b/demo/mbot_demo/package.xml
@@ -16,9 +16,6 @@
   <exec_depend>urdf</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
-  <exec_depend>joint_state_broadcaster</exec_depend>
-  <exec_depend>joint_trajectory_controller</exec_depend>
-  <exec_depend>diff_drive_controller</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/demo/mbot_demo/readme.md
+++ b/demo/mbot_demo/readme.md
@@ -34,7 +34,7 @@ __Here, mbot is used instead of chassis.__
 - *config/joint_limits.yaml*
 - *config/kinematics.yaml*
 - *config/ompl_planning.yaml*
-- __Note__
+- __注__
   - __You can copy the corresponding xarm configuration from xarm_moveit_config/config and then add the mbot configuration__
   - __The demo does not add any mbot configuration.__
 

--- a/uf_ros_lib/pyproject.toml
+++ b/uf_ros_lib/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=61.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+# This tells setuptools to look at the setup.py for metadata

--- a/uf_ros_lib/setup.py
+++ b/uf_ros_lib/setup.py
@@ -12,14 +12,15 @@ setup(
         ('share/' + package_name, ['package.xml']),
     ],
     install_requires=['setuptools'],
-    zip_safe=True,
+    zip_safe=False,
     maintainer='vm',
     maintainer_email='vinman.cub@gmail.com',
     description='TODO: Package description',
     license='TODO: License declaration',
-    tests_require=['pytest'],
+    # extras_require={
+    #     'test': ['pytest'],
+    # },
     entry_points={
-        'console_scripts': [
-        ],
+        'console_scripts': [],
     },
 )

--- a/uf_ros_lib/uf_ros_lib/uf_robot_utils.py
+++ b/uf_ros_lib/uf_ros_lib/uf_robot_utils.py
@@ -65,7 +65,7 @@ def merge_dict(dict1, dict2):
 
 
 def load_abspath_yaml(path):
-    if path and os.path.exists(path):
+    if os.path.exists(path):
         try:
             with open(path, 'r') as file:
                 return yaml.safe_load(file)
@@ -74,36 +74,28 @@ def load_abspath_yaml(path):
     return {}
 
 
-def generate_robot_api_params(default_robot_api_params_path, user_robot_api_params_path=None, ros_namespace='', node_name='ufactory_driver', extra_robot_api_params_path=None):
-    if not user_robot_api_params_path or not os.path.exists(user_robot_api_params_path):
-        user_robot_api_params_path = None
-    if not extra_robot_api_params_path or not os.path.exists(extra_robot_api_params_path):
-        extra_robot_api_params_path = None
-    if ros_namespace or (user_robot_api_params_path is not None and user_robot_api_params_path != default_robot_api_params_path) or (extra_robot_api_params_path is not None and extra_robot_api_params_path != default_robot_api_params_path):
-        ronbot_api_params_yaml = load_abspath_yaml(default_robot_api_params_path)
-        user_params_yaml = load_abspath_yaml(user_robot_api_params_path)
-        extra_params_yaml = load_abspath_yaml(extra_robot_api_params_path)
+def generate_robot_api_params(robot_default_params_path, robot_user_params_path=None, ros_namespace='', node_name='ufactory_driver'):
+    if not os.path.exists(robot_user_params_path):
+        robot_user_params_path = None
+    if ros_namespace or (robot_user_params_path is not None and robot_default_params_path != robot_user_params_path):
+        ros2_control_params_yaml = load_abspath_yaml(robot_default_params_path)
+        ros2_control_user_params_yaml = load_abspath_yaml(robot_user_params_path)
         # change xarm_driver to ufactory_driver
-        if 'xarm_driver' in ronbot_api_params_yaml and node_name not in ronbot_api_params_yaml:
-            ronbot_api_params_yaml[node_name] = ronbot_api_params_yaml.pop('xarm_driver')
-        if 'xarm_driver' in user_params_yaml and node_name not in user_params_yaml:
-            user_params_yaml[node_name] = user_params_yaml.pop('xarm_driver')
-        if 'xarm_driver' in extra_params_yaml and node_name not in extra_params_yaml:
-            extra_params_yaml[node_name] = extra_params_yaml.pop('xarm_driver')
-        if user_params_yaml:
-            merge_dict(ronbot_api_params_yaml, user_params_yaml)
-        if extra_params_yaml:
-            merge_dict(ronbot_api_params_yaml, extra_params_yaml)
+        if 'xarm_driver' in ros2_control_params_yaml and node_name not in ros2_control_params_yaml:
+            ros2_control_params_yaml[node_name] = ros2_control_params_yaml.pop('xarm_driver')
+        if 'xarm_driver' in ros2_control_user_params_yaml and node_name not in ros2_control_user_params_yaml:
+            ros2_control_user_params_yaml[node_name] = ros2_control_user_params_yaml.pop('xarm_driver')
+        merge_dict(ros2_control_params_yaml, ros2_control_user_params_yaml)
         if ros_namespace:
-            robot_params_yaml = {
-                ros_namespace: ronbot_api_params_yaml
+            xarm_params_yaml = {
+                ros_namespace: ros2_control_params_yaml
             }
         else:
-            robot_params_yaml = ronbot_api_params_yaml
+            xarm_params_yaml = ros2_control_params_yaml
         with NamedTemporaryFile(mode='w', prefix='launch_params_', delete=False) as h:
-            yaml.dump(robot_params_yaml, h, default_flow_style=False)
+            yaml.dump(xarm_params_yaml, h, default_flow_style=False)
             return h.name
-    return default_robot_api_params_path
+    return robot_default_params_path
 
 
 def load_yaml(package_name, *file_path):

--- a/xarm_api/ReadMe.md
+++ b/xarm_api/ReadMe.md
@@ -32,18 +32,18 @@
 
 &ensp;&ensp;First startup the service server for xarm7, ip address is just an example:  
 ```bash
-ros2 launch xarm_api xarm7_driver.launch.py robot_ip:=192.168.1.127 report_type:=normal
+$ ros2 launch xarm_api xarm7_driver.launch.py robot_ip:=192.168.1.127 report_type:=normal
 ```
 The argument `report_type` is explained [here](#11-report_type-argument).  
 
 &ensp;&ensp;Then make sure all the servo motors are enabled:
 ```bash
-ros2 service call /xarm/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
+$ ros2 service call /xarm/motion_enable xarm_msgs/srv/SetInt16ById "{id: 8, data: 1}"
 ```
 &ensp;&ensp;Before any motion commands, set proper robot mode(0: POSE, as example) and state(0: READY) ***in order***:    
 ```bash
-ros2 service call /xarm/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
-ros2 service call /xarm/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
+$ ros2 service call /xarm/set_mode xarm_msgs/srv/SetInt16 "{data: 0}"
+$ ros2 service call /xarm/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
 ```
 
 ## 2. Joint or Cartesian space command example [use firmware planner]:
@@ -52,68 +52,68 @@ ros2 service call /xarm/set_state xarm_msgs/srv/SetInt16 "{data: 0}"
 ### 2.1 Joint space motion:
 &ensp;&ensp; To call joint space (7DOF) motion with max speed 0.35 rad/s and acceleration 10 rad/s^2:   
 ```bash
-ros2 service call /xarm/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.28, 0, 0, 0, 0, 0, 0], speed: 0.35, acc: 10}"
+$ ros2 service call /xarm/set_servo_angle xarm_msgs/srv/MoveJoint "{angles: [-0.28, 0, 0, 0, 0, 0, 0], speed: 0.35, acc: 10}"
 ```
 Note: This command is valid for both **Mode 0** and **mode 6**. The difference is: In mode 0 each received command will be **queued** and executed fully in order, whereas in mode 6(must specify `wait` as `false`), the newly received target will take effect immediately and all previous commands will be **discarded**.   
 
 &ensp;&ensp;To go back to home (all joints at 0 rad) position with max speed 0.35 rad/s and acceleration 10 rad/s^2:  
 ```bash
-ros2 service call /xarm/move_gohome xarm_msgs/srv/MoveHome "{speed: 0.35, acc: 10}"
+$ ros2 service call /xarm/move_gohome xarm_msgs/srv/MoveHome "{speed: 0.35, acc: 10}"
 ```
 ### 2.2 Cartesian space motion in Base coordinate:
 &ensp;&ensp;To call Cartesian motion to the target expressed in robot BASE Coordinate, with max speed 200 mm/s and acceleration 2000 mm/s^2:
 ```bash
-ros2 service call /xarm/set_position xarm_msgs/srv/MoveCartesian "{pose: [300, 0, 250, 3.14, 0, 0], speed: 200, acc: 2000}"
+$ ros2 service call /xarm/set_position xarm_msgs/srv/MoveCartesian "{pose: [300, 0, 250, 3.14, 0, 0], speed: 200, acc: 2000}"
 ```
 Note: This command is valid for both **Mode 0** and **mode 7**. The difference is: In mode 0 each received command will be **queued** and executed fully in order, whereas in mode 7(must specify `wait` as `false`), the newly received target will take effect immediately and all previous commands will be **discarded**.   
 
 ### 2.3 Cartesian space motion in Tool coordinate:
 &ensp;&ensp;To execute Cartesian motion expressed in robot TOOL Coordinate, with max speed 50 mm/s and acceleration 1000 mm/s^2, the following will move a **relative motion** (delta_x=50mm, delta_y=100mm, delta_z=100mm) along the current Tool coordinate, no orientation change:
 ```bash
-ros2 service call /xarm/set_tool_position xarm_msgs/srv/MoveCartesian "{pose: [50, 100, 100, 0, 0, 0], speed: 50, acc: 1000}"
+$ ros2 service call /xarm/set_tool_position xarm_msgs/srv/MoveCartesian "{pose: [50, 100, 100, 0, 0, 0], speed: 50, acc: 1000}"
 ```
 ### 2.4 Cartesian space motion in Axis-angle orientation:
 &ensp;&ensp;Please pay attention to two special arguments: "**is_tool_coord**" is `false` for motion with respect to (w.r.t.) Arm base coordinate system, and `true` for motion w.r.t. Tool coordinate system. "**relative**" is `false` for absolute target position w.r.t. specified coordinate system, and `true` for relative target position.  
 &ensp;&ensp;For example: to move 1.0 radian relatively around tool-frame Z-axis: 
 ```bash
-ros2 service call /xarm/set_position_aa xarm_msgs/srv/MoveCartesian "{pose: [0, 0, 0, 0, 0, 1.0], speed: 50, acc: 1000, is_tool_coord: true}"
+$ ros2 service call /xarm/set_position_aa xarm_msgs/srv/MoveCartesian "{pose: [0, 0, 0, 0, 0, 1.0], speed: 50, acc: 1000, is_tool_coord: true}"
 ```   
 &ensp;&ensp;"**mvtime**" is not meaningful in this command, just set it to 0. Another example: in base-frame, to move 122mm relatively along Y-axis, and rotate around X-axis for -0.5 radians:  
 ```bash
-ros2 service call /xarm/set_position_aa xarm_msgs/srv/MoveCartesian "{pose: [0, 122, 0, -0.5, 0, 0], speed: 100, acc: 1000, is_tool_coord: false, relative: true}"  
+$ ros2 service call /xarm/set_position_aa xarm_msgs/srv/MoveCartesian "{pose: [0, 122, 0, -0.5, 0, 0], speed: 100, acc: 1000, is_tool_coord: false, relative: true}"  
 ```
 ### 2.5 Joint velocity control:
 &ensp;&ensp;(**xArm controller firmware version >= 1.6.8** required) If controlling joint velocity is desired, first switch to **Mode 4** as descriped in [mode explanation](https://docs.ufactory.cc/support_articles/faq/robot-state-and-mode-explanation). Please check the [MoveVelocity.srv](../xarm_msgs/srv/MoveVelocity.srv) first to understand the meanings of parameters reqired. If more than one joint are to move, set **is_sync** to `true` for synchronized acceleration/deceleration for all joints in motion, and if is_sync is `false`, each joint will reach to its target velocity as fast as possible. ***is_tool_coord*** parameter is not used here. For example: 
 ```bash
 # NO Timed-out version (will not stop until all-zero velocity command received!):
-ros2 service call /xarm/vc_set_joint_velocity xarm_msgs/srv/MoveVelocity "{speeds: [-0.1, 0, 0, 0, 0, 0, 0.2], is_sync: true}"
+$ ros2 service call /xarm/vc_set_joint_velocity xarm_msgs/srv/MoveVelocity "{speeds: [-0.1, 0, 0, 0, 0, 0, 0.2], is_sync: true}"
 # With Timed-out version(controller firmware version >= 1.8.0): (if next velocity command not received within 0.2 seconds, xArm will stop)  
-ros2 service call /xarm/vc_set_joint_velocity xarm_msgs/srv/MoveVelocity "{speeds: [-0.1, 0, 0, 0, 0, 0, 0.2], is_sync: true, duration: 0.2}"
+$ ros2 service call /xarm/vc_set_joint_velocity xarm_msgs/srv/MoveVelocity "{speeds: [-0.1, 0, 0, 0, 0, 0, 0.2], is_sync: true, duration: 0.2}"
 ``` 
 will command the joints (for xArm7) to move in specified angular velocities (in rad/s) and they will reach to target velocities synchronously. The maximum joint acceleration can also be configured by (unit: rad/s^2):  
 ```bash
-ros2 service call /xarm/set_joint_maxacc xarm_msgs/srv/SetFloat32 "{data: 10.0}"  (maximum: 20.0 rad/s^2)
+$ ros2 service call /xarm/set_joint_maxacc xarm_msgs/srv/SetFloat32 "{data: 10.0}"  (maximum: 20.0 rad/s^2)
 ``` 
 
 ### 2.6 Cartesian velocity control:
 &ensp;&ensp;(**xArm controller firmware version >= 1.6.8** required) If controlling linar velocity of TCP towards certain direction is desired, first switch to **Mode 5** as descriped in [mode explanation](https://docs.ufactory.cc/support_articles/faq/robot-state-and-mode-explanation).  Please check the [MoveVelocity.srv](../xarm_msgs/srv/MoveVelocity.srv) first to understand the meanings of parameters reqired. Set **is_tool_coord** to `false` for motion in world/base coordinate system and `true` for tool coordinate system. ***is_sync*** parameter is not used here. For example: 
 ```bash
 # NO Timed-out version (will not stop until all-zero velocity command received!):  
-ros2 service call /xarm/vc_set_cartesian_velocity xarm_msgs/srv/MoveVelocity "{speeds: [30, 0, 0, 0, 0, 0.1], is_tool_coord: true}"  
+$ ros2 service call /xarm/vc_set_cartesian_velocity xarm_msgs/srv/MoveVelocity "{speeds: [30, 0, 0, 0, 0, 0.1], is_tool_coord: true}"  
 # With Timed-out version(controller firmware version >= 1.8.0): (if next velocity command not received within 0.5 seconds, xArm will stop)  
-ros2 service call /xarm/vc_set_cartesian_velocity xarm_msgs/srv/MoveVelocity "{speeds: [30, 0, 0, 0, 0, 0.1], is_tool_coord: true, duration: 0.5}"
+$ ros2 service call /xarm/vc_set_cartesian_velocity xarm_msgs/srv/MoveVelocity "{speeds: [30, 0, 0, 0, 0, 0.1], is_tool_coord: true, duration: 0.5}"
 ``` 
 will command xArm TCP move along X-axis of TOOL coordinate system with speed of 30 mm/s and rotate around Z axis at 0.1 rad/s. The maximum linear acceleration can also be configured by (unit: mm/s^2):  
 ```bash
-ros2 service call /xarm/set_tcp_maxacc xarm_msgs/srv/SetFloat32 "{data: 2500}" (maximum: 50000 mm/s^2)
+$ ros2 service call /xarm/set_tcp_maxacc xarm_msgs/srv/SetFloat32 "{data: 2500}" (maximum: 50000 mm/s^2)
 ``` 
 
 For angular motion in orientation, please note the velocity is specified as **axis-angular_velocity** elements. That is, [the unit rotation axis vector] multiplied by [rotation velocity value(scalar)]. For example, 
 ```bash
 # NO Timed-out version (will not stop until all-zero velocity command received!):
-ros2 service call /xarm/vc_set_cartesian_velocity xarm_msgs/srv/MoveVelocity "{speeds: [0, 0, 0, 0.707, 0, 0], is_tool_coord: false}"
+$ ros2 service call /xarm/vc_set_cartesian_velocity xarm_msgs/srv/MoveVelocity "{speeds: [0, 0, 0, 0.707, 0, 0], is_tool_coord: false}"
 # With Timed-out version(controller firmware version >= 1.8.0): (if next velocity command not received within 0.2 seconds, xArm will stop)  
-ros2 service call /xarm/vc_set_cartesian_velocity xarm_msgs/srv/MoveVelocity "{speeds: [0, 0, 0, 0.707, 0, 0], is_tool_coord: false, duration: 0.2}"
+$ ros2 service call /xarm/vc_set_cartesian_velocity xarm_msgs/srv/MoveVelocity "{speeds: [0, 0, 0, 0.707, 0, 0], is_tool_coord: false, duration: 0.2}"
 ``` 
 This will command TCP to rotate along X-axis in BASE coordinates at about 45 degrees/sec. The maximum acceleration for orientation change is fixed.  
 
@@ -141,18 +141,18 @@ Now with xArm controller **Firmware Version >= 1.4.1**, user can send streamed C
   
 Suppose current TCP position is at [206, 0, 121, 3.1416, 0, 0]
 ```bash
-ros2 service call /xarm/set_servo_cartesian xarm_msgs/srv/MoveCartesian "{pose: [208, 0, 121, 3.1416, 0, 0]}"
+$ ros2 service call /xarm/set_servo_cartesian xarm_msgs/srv/MoveCartesian "{pose: [208, 0, 121, 3.1416, 0, 0]}"
 ```
 Now please check the current TCP position, it will execute this target immediately if success. If you want continuous motion alone X axis, you can give the following pose like:
 ```bash
-ros2 service call /xarm/set_servo_cartesian xarm_msgs/srv/MoveCartesian "{pose: [210, 0, 121, 3.1416, 0, 0]}"
+$ ros2 service call /xarm/set_servo_cartesian xarm_msgs/srv/MoveCartesian "{pose: [210, 0, 121, 3.1416, 0, 0]}"
 ```
 And you can program this service calling procedure in a loop with proper intervals inbetween, the final execution will become smooth.   
 
 **Notice: Servo_cartisian in TOOL coordinate:**
 Please update the controller Firmware to version >= 1.5.0. If servo_cartesian in Tool Coordinate is needed, **set "is_tool_coord" to be true**, the resulted motion will base on current Tool coordinate. For example:  
 ```bash
-ros2 service call /xarm/set_servo_cartesian xarm_msgs/srv/MoveCartesian "{pose: [0, 0, 2, 0, 0, 0], is_tool_coord: true}"
+$ ros2 service call /xarm/set_servo_cartesian xarm_msgs/srv/MoveCartesian "{pose: [0, 0, 2, 0, 0, 0], is_tool_coord: true}"
 ```
 This will make TCP to move 2 mm immediately along +Z Axis in **TOOL Coordinate**. You may also use `xarm/set_servo_cartesian_aa` service for axis-angle expression command.  
 
@@ -162,7 +162,7 @@ There is also a similar service called "**/xarm/set_servo_angle_j**", you can us
 
 For example, if /xarm/joint_state says current joint positions are:  [0.25,-0.47,0.0,-0.28,0.0,0.76,0.24], you can call:  
 ```bash
-ros2 service call /xarm/set_servo_angle_j xarm_msgs/srv/MoveJoint "{angles: [0.25,-0.47,0.0,-0.28,0.0,0.76,0.25]}"
+$ ros2 service call /xarm/set_servo_angle_j xarm_msgs/srv/MoveJoint "{angles: [0.25,-0.47,0.0,-0.28,0.0,0.76,0.25]}"
 ```
 Which will move joint7 by 0.01 rad **immediately**. Keep calling it and increase the joint positions a small step each time, it will move smoothly. **Be careful not to give a target too far away in one single update**.  
 
@@ -172,15 +172,15 @@ Which will move joint7 by 0.01 rad **immediately**. Keep calling it and increase
 &ensp;&ensp;We provide 2 digital, 2 analog input port and 2 digital output signals at the end I/O connector.  
 ### 4.1 To get current 2 DIGITAL input states:  
 ```bash
-ros2 service call /xarm/get_tgpio_digital xarm_msgs/srv/GetDigitalIO 
+$ ros2 service call /xarm/get_tgpio_digital xarm_msgs/srv/GetDigitalIO 
 ```
 ### 4.2 To get one of the ANALOG input value: 
 ```bash
-ros2 service call /xarm/get_tgpio_analog xarm_msgs/srv/GetAnalogIO "{ionum: 0}"  (io number, can only be 0 or 1)
+$ ros2 service call /xarm/get_tgpio_analog xarm_msgs/srv/GetAnalogIO "{ionum: 0}"  (io number, can only be 0 or 1)
 ```
 ### 4.3 To set one of the Digital output:
 ```bash
-ros2 service call /xarm/set_tgpio_digital xarm_msgs/srv/SetDigitalIO "{ionum: 0, value: 1}"  (Setting output port 0 to be 1)
+$ ros2 service call /xarm/set_tgpio_digital xarm_msgs/srv/SetDigitalIO "{ionum: 0, value: 1}"  (Setting output port 0 to be 1)
 ```
 &ensp;&ensp;You have to make sure the operation is successful by checking responding "ret" to be 0.
 
@@ -190,27 +190,27 @@ ros2 service call /xarm/set_tgpio_digital xarm_msgs/srv/SetDigitalIO "{ionum: 0,
 
 ### 5.1 To get all of the controller DIGITAL input state:  
 ```bash
-ros2 service call /xarm/get_cgpio_digital xarm_msgs/srv/GetDigitalIO  # (Notice: from 1st to 8th, for CO0~CO7; from 9th to 16th, for DI0~DI7[if any])
+$ ros2 service call /xarm/get_cgpio_digital xarm_msgs/srv/GetDigitalIO  # (Notice: from 1st to 8th, for CO0~CO7; from 9th to 16th, for DI0~DI7[if any])
 ```
 ### 5.2 To set one of the controller DIGITAL output:
 ```bash
-ros2 service call /xarm/set_cgpio_digital xarm_msgs/srv/SetDigitalIO "{ionum: 0, value: 1}" 
+$ ros2 service call /xarm/set_cgpio_digital xarm_msgs/srv/SetDigitalIO "{ionum: 0, value: 1}" 
 ```
 &ensp;&ensp;Please note port number starts from 0, for example:  
 ```bash
-ros2 service call /xarm/set_cgpio_digital xarm_msgs/srv/SetDigitalIO "{ionum: 4, value: 1}"   #(Setting 5th [lable C04] output port to be 1)
+$ ros2 service call /xarm/set_cgpio_digital xarm_msgs/srv/SetDigitalIO "{ionum: 4, value: 1}"   #(Setting 5th [lable C04] output port to be 1)
 ```
 ### 5.3 To get one of the controller ANALOG input:
 ```bash
-ros2 service call /xarm/get_cgpio_analog xarm_msgs/srv/GetAnalogIO "{ionum: <port_num>}"  # ionum: 0 or 1
+$ ros2 service call /xarm/get_cgpio_analog xarm_msgs/srv/GetAnalogIO "{ionum: <port_num>}"  # ionum: 0 or 1
 ```
 ### 5.4 To set one of the controller ANALOG output:
 ```bash
-ros2 service call /xarm/set_cgpio_analog xarm_msgs/srv/SetAnalogIO  "{ionum: <port_num>, value: <target_value>}"
+$ ros2 service call /xarm/set_cgpio_analog xarm_msgs/srv/SetAnalogIO  "{ionum: <port_num>, value: <target_value>}"
 ```
 &ensp;&ensp;For example:  
 ```bash
-ros2 service call /xarm/set_cgpio_analog xarm_msgs/srv/SetAnalogIO  "{ionum: 1, value: 3.3}"  #(Setting port AO1 to be 3.3)
+$ ros2 service call /xarm/set_cgpio_analog xarm_msgs/srv/SetAnalogIO  "{ionum: 1, value: 3.3}"  #(Setting port AO1 to be 3.3)
 ```
 &ensp;&ensp;You have to make sure the operation is successful by checking responding "ret" to be 0.
 
@@ -222,11 +222,11 @@ ros2 service call /xarm/set_cgpio_analog xarm_msgs/srv/SetAnalogIO  "{ionum: 1, 
 ## 7. Clearing Errors:
 &ensp;&ensp;Sometimes controller may report error or warnings that would affect execution of further commands. The reasons may be power loss, position/speed limit violation, planning errors, etc. It needs additional intervention to clear. User can check error code ("err" field) in the message of topic ***"xarm/robot_states"*** . 
 ```bash
-ros2 topic echo /xarm/robot_states
+$ ros2 topic echo /xarm/robot_states
 ```
 &ensp;&ensp;If it is non-zero, the corresponding reason can be found out in the user manual. After solving the problem, this error satus can be removed by calling service ***"/xarm/clean_error"*** with empty argument.
 ```bash
-ros2 service call /xarm/clean_error xarm_msgs/srv/Call
+$ ros2 service call /xarm/clean_error xarm_msgs/srv/Call
 ```
 &ensp;&ensp;After calling `clean_error` service, please ***check the err status again*** in 'xarm/robot_states', if it becomes 0, the clearing is successful. Otherwise, it means the error/exception is not properly solved. If using Moveit!, please set mode to 1 again manually, since controller error and state 4 will automatically switch mode back to 0. If clearing error is successful, remember to ***set robot state to 0*** to make it ready to move again!   
 
@@ -236,28 +236,28 @@ ros2 service call /xarm/clean_error xarm_msgs/srv/Call
 ### 8.1 Gripper services:  
 (1) Upon powering up, first enable the griper and configure the grasp speed:  
 ```bash
-ros2 service call /xarm/set_gripper_enable xarm_msgs/srv/SetInt16 "{data: 1}"
-ros2 service call /xarm/set_gripper_mode xarm_msgs/srv/SetInt16 "{data: 0}"
-ros2 service call /xarm/set_gripper_speed xarm_msgs/srv/SetFloat32 "{data: 1500}"
+$ ros2 service call /xarm/set_gripper_enable xarm_msgs/srv/SetInt16 "{data: 1}"
+$ ros2 service call /xarm/set_gripper_mode xarm_msgs/srv/SetInt16 "{data: 0}"
+$ ros2 service call /xarm/set_gripper_speed xarm_msgs/srv/SetFloat32 "{data: 1500}"
 ```
 &ensp;&ensp; Proper range of the speed is ***from 1 to 5000***. 1500 is used as an example. 'ret' value is 0 for success.  
 (2) Give position command (open distance) to xArm gripper:  
 ```bash
-ros2 service call /xarm/set_gripper_position xarm_msgs/srv/GripperMove "{pos: 500}"
+$ ros2 service call /xarm/set_gripper_position xarm_msgs/srv/GripperMove "{pos: 500}"
 ```
 &ensp;&ensp; Proper range of the open distance is ***from 0 to 850***. 0 is closed, 850 is fully open. 500 is used as an example. 'ret' value is 0 for success.  
 
 (3) To get the current status (position and error_code) of xArm gripper:
 ```bash
-ros2 service call /xarm/get_gripper_position xarm_msgs/srv/GetFloat32
-ros2 service call /xarm/get_gripper_err_code xarm_msgs/srv/GetInt16
+$ ros2 service call /xarm/get_gripper_position xarm_msgs/srv/GetFloat32
+$ ros2 service call /xarm/get_gripper_err_code xarm_msgs/srv/GetInt16
 ```
 &ensp;&ensp; If error code is non-zero, please refer to user manual for the cause of error, the "/xarm/clear_err" service can still be used to clear the error code of xArm Gripper.  
 
 ### 8.2 Gripper action:
 &ensp;&ensp; The xArm gripper move action is `xarm_gripper/gripper_action`, which is of type `control_msgs/action/GripperCommand`. **Attention:** The goal position here should be the rotation angle of the virtual joint inside, which is **from 0 rad (fully open) to 0.86 (fully closed)**. Not the pulse in afore-mentioned service call. Gripper action can be called by:  
 ```bash
-ros2 action send_goal /xarm_gripper/gripper_action control_msgs/action/GripperCommand "{command: {position: 0.5, max_effort: 0}}"
+$ ros2 action send_goal /xarm_gripper/gripper_action control_msgs/action/GripperCommand "{command: {position: 0.5, max_effort: 0}}"
 ```
 
 ## 9. Vacuum Gripper Control:
@@ -265,11 +265,11 @@ ros2 action send_goal /xarm_gripper/gripper_action control_msgs/action/GripperCo
 
 &ensp;&ensp;To turn on:  
 ```bash
-ros2 service call /xarm/set_vacuum_gripper xarm_msgs/srv/VacuumGripperCtrl "{'on': true}"
+$ ros2 service call /xarm/set_vacuum_gripper xarm_msgs/srv/VacuumGripperCtrl "{'on': true}"
 ```
 &ensp;&ensp;To turn off:  
 ```bash
-ros2 service call /xarm/set_vacuum_gripper xarm_msgs/srv/VacuumGripperCtrl "{'on': false}"
+$ ros2 service call /xarm/set_vacuum_gripper xarm_msgs/srv/VacuumGripperCtrl "{'on': false}"
 ```
 &ensp;&ensp;0 will be returned upon successful execution.  
 
@@ -277,14 +277,14 @@ ros2 service call /xarm/set_vacuum_gripper xarm_msgs/srv/VacuumGripperCtrl "{'on
 ## 10. Tool Modbus communication:
 If modbus communication with the tool device is needed, please first set the proper baud rate and timeout parameters through the relevant services: 
 ```bash
-ros2 service call /xarm/set_tgpio_modbus_baudrate xarm_msgs/srv/SetInt32 "{data: 115200}"
-ros2 service call /xarm/set_tgpio_modbus_timeout xarm_msgs/srv/SetModbusTimeout "{timeout: 20}"  # unit: ms
+$ ros2 service call /xarm/set_tgpio_modbus_baudrate xarm_msgs/srv/SetInt32 "{data: 115200}"
+$ ros2 service call /xarm/set_tgpio_modbus_timeout xarm_msgs/srv/SetModbusTimeout "{timeout: 20}"  # unit: ms
 ```
 The above command will configure the tool modbus baudrate to be 115200 bps and timeout threshold to be 20 **ms**. It is not necessary to configure again if these properties are not changed afterwards. Currently, only the following baud rates (bps) are supported: [4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600, 1000000, 1500000, 2000000, 2500000].  
 
 Then the communication can be conducted like (refer to [GetSetModbusData.srv](../xarm_msgs/srv/GetSetModbusData.srv) for more parameter details):  
 ```bash
-ros2 service call /xarm/getset_tgpio_modbus_data xarm_msgs/srv/GetSetModbusData "{modbus_data: [0x01,0x06,0x00,0x0A,0x00,0x03]}"
+$ ros2 service call /xarm/getset_tgpio_modbus_data xarm_msgs/srv/GetSetModbusData "{modbus_data: [0x01,0x06,0x00,0x0A,0x00,0x03]}"
 ```
 please check the `ret_data` field for device response data.   
 

--- a/xarm_api/config/xarm_params.yaml
+++ b/xarm_api/config/xarm_params.yaml
@@ -3,9 +3,6 @@
 ufactory_driver:
   ros__parameters:
     joint_names: ['joint1', 'joint2', 'joint3', 'joint4', 'joint5', 'joint6', 'joint7']
-    joint_states:
-      rate: -1
-      flags: -1
     xarm_gripper:
       joint_names: ['drive_joint', 'left_finger_joint', 'left_inner_knuckle_joint', 'right_outer_knuckle_joint', 'right_finger_joint', 'right_inner_knuckle_joint']
       speed: 2000
@@ -26,9 +23,9 @@ ufactory_driver:
       clean_bio_gripper_error: false
       start_record_trajectory: false
       stop_record_trajectory: false
-      set_ft_sensor_zero: false       # The old name is ft_sensor_set_zero, please use the new one
-      set_linear_motor_stop: false    # The old name is set_linear_track_stop, please use the new one
-      clean_linear_motor_error: false # The old name is clean_linear_track_error, please use the new one
+      ft_sensor_set_zero: false
+      set_linear_track_stop: false
+      clean_linear_track_error: false
       open_lite6_gripper: false
       close_lite6_gripper: false
       stop_lite6_gripper: false
@@ -40,24 +37,24 @@ ufactory_driver:
       get_bio_gripper_error: false
       get_reduced_mode: false
       get_report_tau_or_i: false
-      get_ft_sensor_mode: false           # The old name is ft_sensor_app_get, please use the new one
+      ft_sensor_app_get: false
       get_ft_sensor_error: false
       get_trajectory_rw_status: false
-      get_linear_motor_pos: false         # The old name is get_linear_track_pos, please use the new one
-      get_linear_motor_status: false      # The old name is get_linear_track_status, please use the new one
-      get_linear_motor_error: false       # The old name is get_linear_track_error, please use the new one
-      get_linear_motor_is_enabled: false  # The old name is get_linear_track_is_enabled, please use the new one
-      get_linear_motor_on_zero: false     # The old name is get_linear_track_on_zero, please use the new one
-      get_linear_motor_sci: false         # The old name is get_linear_track_sci, please use the new one
+      get_linear_track_pos: false
+      get_linear_track_status: false
+      get_linear_track_error: false
+      get_linear_track_is_enabled: false
+      get_linear_track_on_zero: false
+      get_linear_track_sci: false
       get_err_warn_code: false
-      get_linear_motor_sco: false         # The old name is get_linear_track_sco, please use the new one
+      get_linear_track_sco: false
       set_mode: true
       set_state: true
       set_collision_sensitivity: false
       set_teach_sensitivity: false
       set_gripper_mode: false
       set_gripper_enable: false
-      set_tgpio_modbus_timeout: false
+      set_tgpio_modbus_timeout: true
       set_bio_gripper_speed: false
       set_collision_rebound: false
       set_fence_mode: false
@@ -66,10 +63,10 @@ ufactory_driver:
       set_simulation_robot: false
       set_baud_checkset_enable: false
       set_report_tau_or_i: false
-      set_ft_sensor_enable: false     # The old name is ft_sensor_enable, please use the new one
-      set_ft_sensor_mode: false       # The old name is ft_sensor_app_set, please use the new one
-      set_linear_motor_enable: false  # The old name is set_linear_track_enable, please use the new one
-      set_linear_motor_speed: false   # The old name is set_linear_track_speed, please use the new one
+      ft_sensor_enable: false
+      ft_sensor_app_set: false
+      set_linear_track_enable: false
+      set_linear_track_speed: false
       set_cartesian_velo_continuous: false
       set_allow_approx_motion: false
       set_only_check_type: false
@@ -79,8 +76,8 @@ ufactory_driver:
       set_servo_attach: false
       set_servo_detach: false
       set_reduced_tcp_boundary: false
-      get_tgpio_modbus_baudrate: false
-      set_tgpio_modbus_baudrate: false
+      get_tgpio_modbus_baudrate: true
+      set_tgpio_modbus_baudrate: true
       get_checkset_default_baud: false
       set_checkset_default_baud: false
       get_gripper_position: false
@@ -100,7 +97,7 @@ ufactory_driver:
       set_tcp_offset: false
       set_world_offset: false
       set_reduced_joint_range: false
-      set_tcp_load: false
+      set_tcp_load: true
       set_position: true
       set_tool_position: false
       set_position_aa: false
@@ -112,16 +109,16 @@ ufactory_driver:
       move_gohome: true
       vc_set_joint_velocity: true
       vc_set_cartesian_velocity: true
-      get_tgpio_digital: false
-      get_cgpio_digital: false
-      get_tgpio_analog: false
-      get_cgpio_analog: false
-      set_tgpio_digital: false
-      set_cgpio_digital: false
-      set_tgpio_digital_with_xyz: false
-      set_cgpio_digital_with_xyz: false
-      set_cgpio_analog: false
-      set_cgpio_analog_with_xyz: false
+      get_tgpio_digital: true
+      get_cgpio_digital: true
+      get_tgpio_analog: true
+      get_cgpio_analog: true
+      set_tgpio_digital: true
+      set_cgpio_digital: true
+      set_tgpio_digital_with_xyz: true
+      set_cgpio_digital_with_xyz: true
+      set_cgpio_analog: true
+      set_cgpio_analog_with_xyz: true
       set_vacuum_gripper: false
       set_gripper_position: false
       set_bio_gripper_enable: false
@@ -133,14 +130,16 @@ ufactory_driver:
       robotiq_open: false
       robotiq_close: false
       robotiq_get_status: false
-      getset_tgpio_modbus_data: false
+      getset_tgpio_modbus_data: true
       save_record_trajectory: false
       load_trajectory: false
       playback_trajectory: false
       iden_tcp_load: false
-      iden_ft_sensor_load_offset: false   # The old name is ft_sensor_iden_load, please use the new one
-      set_ft_sensor_load_offset: false    # The old name is ft_sensor_cali_load, please use the new one
+      ft_sensor_iden_load: false
+      ft_sensor_cali_load: false
       config_force_control: false
-      set_ft_sensor_admittance_parameters: false  # The old name is set_impedance/set_impedance_mbk/set_impedance_config, please use the new one
-      set_linear_motor_back_origin: false # The old name is set_linear_track_back_origin, please use the new one
-      set_linear_motor_pos: false         # The old name is set_linear_track_pos, please use the new one
+      set_impedance: false
+      set_impedance_mbk: false
+      set_impedance_config: false
+      set_linear_track_back_origin: false
+      set_linear_track_pos: false

--- a/xarm_api/include/xarm_api/xarm_driver.h
+++ b/xarm_api/include/xarm_api/xarm_driver.h
@@ -41,9 +41,6 @@ namespace xarm_api
 
         sensor_msgs::msg::JointState* get_joint_states();
 
-        /* only use in xarm_controller */
-        int update_joint_states(bool initialized = true, int flag = -1);
-
     private:
         void _report_connect_changed_callback(bool connected, bool reported);
         void _report_data_callback(XArmReportData *report_data_ptr);
@@ -55,7 +52,7 @@ namespace xarm_api
         rclcpp_action::CancelResponse _handle_xarm_gripper_action_cancel(const std::shared_ptr<rclcpp_action::ServerGoalHandle<control_msgs::action::GripperCommand>> goal_handle);
         void _handle_xarm_gripper_action_accepted(const std::shared_ptr<rclcpp_action::ServerGoalHandle<control_msgs::action::GripperCommand>> goal_handle);
         void _xarm_gripper_action_execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<control_msgs::action::GripperCommand>> goal_handle);
-        void _pub_xarm_gripper_joint_states(int pos);
+        void _pub_xarm_gripper_joint_states(float pos);
 
         void _init_bio_gripper(void);
         inline float _bio_gripper_pos_convert(float pos, bool reversed = false);
@@ -63,7 +60,7 @@ namespace xarm_api
         rclcpp_action::CancelResponse _handle_bio_gripper_action_cancel(const std::shared_ptr<rclcpp_action::ServerGoalHandle<control_msgs::action::GripperCommand>> goal_handle);
         void _handle_bio_gripper_action_accepted(const std::shared_ptr<rclcpp_action::ServerGoalHandle<control_msgs::action::GripperCommand>> goal_handle);
         void _bio_gripper_action_execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<control_msgs::action::GripperCommand>> goal_handle);
-        void _pub_bio_gripper_joint_states(int pos);
+        void _pub_bio_gripper_joint_states(float pos);
 
         template<typename ServiceT, typename CallbackT>
     	typename rclcpp::Service<ServiceT>::SharedPtr _create_service(const std::string & service_name, CallbackT && callback);
@@ -84,11 +81,8 @@ namespace xarm_api
         rclcpp::Node::SharedPtr node_;
         rclcpp::Node::SharedPtr hw_node_;
 
-        SocketPort *sock_rt_;
-
         int dof_;
-        int joint_state_rate_;
-        int joint_state_flags_;
+        int joint_states_rate_;
         bool in_ros_control_;
         int vacuum_gripper_hardware_version_;
         std::string report_type_;
@@ -141,16 +135,12 @@ namespace xarm_api
         rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_clean_bio_gripper_error_;
         rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_start_record_trajectory_;
         rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_stop_record_trajectory_;
-        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_set_ft_sensor_zero_;
-        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_set_linear_motor_stop_;
-        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_clean_linear_motor_error_;
-        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_open_lite6_gripper_;
-        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_close_lite6_gripper_;
-        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_stop_lite6_gripper_;
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_ft_sensor_set_zero_;
         rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_set_linear_track_stop_;
         rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_clean_linear_track_error_;
+        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_open_lite6_gripper_;
+        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_close_lite6_gripper_;
+        rclcpp::Service<xarm_msgs::srv::Call>::SharedPtr service_stop_lite6_gripper_;
         bool _clean_error(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
         bool _clean_warn(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
         bool _clean_conf(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
@@ -162,9 +152,9 @@ namespace xarm_api
         bool _clean_bio_gripper_error(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
         bool _start_record_trajectory(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
         bool _stop_record_trajectory(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
-        bool _set_ft_sensor_zero(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
-        bool _set_linear_motor_stop(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
-        bool _clean_linear_motor_error(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
+        bool _ft_sensor_set_zero(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
+        bool _set_linear_track_stop(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
+        bool _clean_linear_track_error(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
         bool _open_lite6_gripper(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
         bool _close_lite6_gripper(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
         bool _stop_lite6_gripper(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res);
@@ -178,17 +168,9 @@ namespace xarm_api
         rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_bio_gripper_error_;
         rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_reduced_mode_;
         rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_report_tau_or_i_;
-        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_ft_sensor_mode_;
+        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_ft_sensor_app_get_;
         rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_ft_sensor_error_;
         rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_trajectory_rw_status_;
-        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_motor_pos_;
-        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_motor_status_;
-        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_motor_error_;
-        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_motor_is_enabled_;
-        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_motor_on_zero_;
-        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_motor_sci_;
-        // OLD SERVICE
-        rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_ft_sensor_app_get_;
         rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_track_pos_;
         rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_track_status_;
         rclcpp::Service<xarm_msgs::srv::GetInt16>::SharedPtr service_get_linear_track_error_;
@@ -203,23 +185,21 @@ namespace xarm_api
         bool _get_bio_gripper_error(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
         bool _get_reduced_mode(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
         bool _get_report_tau_or_i(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
-        bool _get_ft_sensor_mode(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
+        bool _ft_sensor_app_get(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
         bool _get_ft_sensor_error(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
         bool _get_trajectory_rw_status(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
-        bool _get_linear_motor_pos(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
-        bool _get_linear_motor_status(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
-        bool _get_linear_motor_error(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
-        bool _get_linear_motor_is_enabled(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
-        bool _get_linear_motor_on_zero(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
-        bool _get_linear_motor_sci(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
+        bool _get_linear_track_pos(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
+        bool _get_linear_track_status(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
+        bool _get_linear_track_error(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
+        bool _get_linear_track_is_enabled(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
+        bool _get_linear_track_on_zero(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
+        bool _get_linear_track_sci(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res);
 
         // GetInt16List
         rclcpp::Service<xarm_msgs::srv::GetInt16List>::SharedPtr service_get_err_warn_code_;
-        rclcpp::Service<xarm_msgs::srv::GetInt16List>::SharedPtr service_get_linear_motor_sco_;
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::GetInt16List>::SharedPtr service_get_linear_track_sco_;
         bool _get_err_warn_code(const std::shared_ptr<xarm_msgs::srv::GetInt16List::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16List::Response> res);
-        bool _get_linear_motor_sco(const std::shared_ptr<xarm_msgs::srv::GetInt16List::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16List::Response> res);
+        bool _get_linear_track_sco(const std::shared_ptr<xarm_msgs::srv::GetInt16List::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16List::Response> res);
 
         // SetInt16
         rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_mode_;
@@ -236,21 +216,15 @@ namespace xarm_api
         rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_simulation_robot_;
         rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_baud_checkset_enable_;
         rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_report_tau_or_i_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_ft_sensor_enable_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_ft_sensor_mode_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_linear_motor_enable_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_linear_motor_speed_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_cartesian_velo_continuous_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_allow_approx_motion_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_only_check_type_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_config_tgpio_reset_when_stop_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_config_cgpio_reset_when_stop_;
-        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_rs485_use_503_port_;
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_ft_sensor_enable_;
         rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_ft_sensor_app_set_;
         rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_linear_track_enable_;
         rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_linear_track_speed_;
+        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_cartesian_velo_continuous_;
+        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_allow_approx_motion_;
+        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_set_only_check_type_;     
+        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_config_tgpio_reset_when_stop_;     
+        rclcpp::Service<xarm_msgs::srv::SetInt16>::SharedPtr service_config_cgpio_reset_when_stop_;     
         bool _set_mode(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _set_state(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _set_collision_sensitivity(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
@@ -265,16 +239,15 @@ namespace xarm_api
         bool _set_simulation_robot(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _set_baud_checkset_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _set_report_tau_or_i(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
-        bool _set_ft_sensor_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
-        bool _set_ft_sensor_mode(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
-        bool _set_linear_motor_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
-        bool _set_linear_motor_speed(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
+        bool _ft_sensor_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
+        bool _ft_sensor_app_set(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
+        bool _set_linear_track_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
+        bool _set_linear_track_speed(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _set_cartesian_velo_continuous(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _set_allow_approx_motion(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _set_only_check_type(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _config_tgpio_reset_when_stop(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
         bool _config_cgpio_reset_when_stop(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
-        bool _set_rs485_use_503_port(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res);
 
         // SetInt16ById
         rclcpp::Service<xarm_msgs::srv::SetInt16ById>::SharedPtr service_motion_enable_;
@@ -287,9 +260,6 @@ namespace xarm_api
         // SetInt16List
         rclcpp::Service<xarm_msgs::srv::SetInt16List>::SharedPtr service_set_reduced_tcp_boundary_;
         bool _set_reduced_tcp_boundary(const std::shared_ptr<xarm_msgs::srv::SetInt16List::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16List::Response> res);
-
-        rclcpp::Service<xarm_msgs::srv::SetInt16List>::SharedPtr service_set_external_device_monitor_params_;
-        bool _set_external_device_monitor_params(const std::shared_ptr<xarm_msgs::srv::SetInt16List::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16List::Response> res);
         
         // GetInt32
         rclcpp::Service<xarm_msgs::srv::GetInt32>::SharedPtr service_get_tgpio_modbus_baudrate_;
@@ -475,55 +445,35 @@ namespace xarm_api
     
         // IdenLoad
         rclcpp::Service<xarm_msgs::srv::IdenLoad>::SharedPtr service_iden_tcp_load_;
-        rclcpp::Service<xarm_msgs::srv::IdenLoad>::SharedPtr service_iden_ft_sensor_load_offset_;
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::IdenLoad>::SharedPtr service_ft_sensor_iden_load_;
         bool _iden_tcp_load(const std::shared_ptr<xarm_msgs::srv::IdenLoad::Request> req, std::shared_ptr<xarm_msgs::srv::IdenLoad::Response> res);
-        bool _iden_ft_sensor_load_offset(const std::shared_ptr<xarm_msgs::srv::IdenLoad::Request> req, std::shared_ptr<xarm_msgs::srv::IdenLoad::Response> res);
+        bool _ft_sensor_iden_load(const std::shared_ptr<xarm_msgs::srv::IdenLoad::Request> req, std::shared_ptr<xarm_msgs::srv::IdenLoad::Response> res);
 
         // FtCaliLoad
-        rclcpp::Service<xarm_msgs::srv::FtCaliLoad>::SharedPtr service_set_ft_sensor_load_offset_;
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::FtCaliLoad>::SharedPtr service_ft_sensor_cali_load_;
-        bool _set_ft_sensor_load_offset(const std::shared_ptr<xarm_msgs::srv::FtCaliLoad::Request> req, std::shared_ptr<xarm_msgs::srv::FtCaliLoad::Response> res);
+        bool _ft_sensor_cali_load(const std::shared_ptr<xarm_msgs::srv::FtCaliLoad::Request> req, std::shared_ptr<xarm_msgs::srv::FtCaliLoad::Response> res);
     
-        // FtForceParams
-        rclcpp::Service<xarm_msgs::srv::FtForceParams>::SharedPtr service_set_ft_force_;
-        bool _set_ft_sensor_force_parameters(const std::shared_ptr<xarm_msgs::srv::FtForceParams::Request> req, std::shared_ptr<xarm_msgs::srv::FtForceParams::Response> res);
         // FtForceConfig
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::FtForceConfig>::SharedPtr service_config_force_control_;
         bool _config_force_control(const std::shared_ptr<xarm_msgs::srv::FtForceConfig::Request> req, std::shared_ptr<xarm_msgs::srv::FtForceConfig::Response> res);
+    
         // FtForcePid
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::FtForcePid>::SharedPtr service_set_force_control_pid_;
         bool _set_force_control_pid(const std::shared_ptr<xarm_msgs::srv::FtForcePid::Request> req, std::shared_ptr<xarm_msgs::srv::FtForcePid::Response> res);
-
-        // FtAdmittanceParams
-        rclcpp::Service<xarm_msgs::srv::FtAdmittanceParams>::SharedPtr service_set_ft_admittance_;
-        bool _set_ft_sensor_admittance_parameters(const std::shared_ptr<xarm_msgs::srv::FtAdmittanceParams::Request> req, std::shared_ptr<xarm_msgs::srv::FtAdmittanceParams::Response> res);
+    
         // FtImpedance
-        // OLD SERVICE
-        rclcpp::Service<xarm_msgs::srv::FtImpedance>::SharedPtr service_set_admittance_;
-        rclcpp::Service<xarm_msgs::srv::FtImpedance>::SharedPtr service_set_admittance_mbk_;
-        rclcpp::Service<xarm_msgs::srv::FtImpedance>::SharedPtr service_set_admittance_config_;
-        bool _set_admittance(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res);
-        bool _set_admittance_mbk(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res);
-        bool _set_admittance_config(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res);
-        
-        // LinearMotorBackOrigin
-        rclcpp::Service<xarm_msgs::srv::LinearMotorBackOrigin>::SharedPtr service_set_linear_motor_back_origin_;
-        bool _set_linear_motor_back_origin(const std::shared_ptr<xarm_msgs::srv::LinearMotorBackOrigin::Request> req, std::shared_ptr<xarm_msgs::srv::LinearMotorBackOrigin::Response> res);
+        rclcpp::Service<xarm_msgs::srv::FtImpedance>::SharedPtr service_set_impedance_;
+        rclcpp::Service<xarm_msgs::srv::FtImpedance>::SharedPtr service_set_impedance_mbk_;
+        rclcpp::Service<xarm_msgs::srv::FtImpedance>::SharedPtr service_set_impedance_config_;
+        bool _set_impedance(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res);
+        bool _set_impedance_mbk(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res);
+        bool _set_impedance_config(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res);
+
         // LinearTrackBackOrigin
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::LinearTrackBackOrigin>::SharedPtr service_set_linear_track_back_origin_;
         bool _set_linear_track_back_origin(const std::shared_ptr<xarm_msgs::srv::LinearTrackBackOrigin::Request> req, std::shared_ptr<xarm_msgs::srv::LinearTrackBackOrigin::Response> res);
-        
-        // LinearMotorSetPos
-        rclcpp::Service<xarm_msgs::srv::LinearMotorSetPos>::SharedPtr service_set_linear_motor_pos_;
-        bool _set_linear_motor_pos(const std::shared_ptr<xarm_msgs::srv::LinearMotorSetPos::Request> req, std::shared_ptr<xarm_msgs::srv::LinearMotorSetPos::Response> res);
+
         // LinearTrackSetPos
-        // OLD SERVICE
         rclcpp::Service<xarm_msgs::srv::LinearTrackSetPos>::SharedPtr service_set_linear_track_pos_;
         bool _set_linear_track_pos(const std::shared_ptr<xarm_msgs::srv::LinearTrackSetPos::Request> req, std::shared_ptr<xarm_msgs::srv::LinearTrackSetPos::Response> res);
     };

--- a/xarm_api/include/xarm_api/xarm_msgs.h
+++ b/xarm_api/include/xarm_api/xarm_msgs.h
@@ -46,12 +46,8 @@
 #include <xarm_msgs/srv/ft_cali_load.hpp>
 #include <xarm_msgs/srv/ft_force_config.hpp>
 #include <xarm_msgs/srv/ft_force_pid.hpp>
-#include <xarm_msgs/srv/ft_force_params.hpp>
 #include <xarm_msgs/srv/ft_impedance.hpp>
-#include <xarm_msgs/srv/ft_admittance_params.hpp>
 #include <xarm_msgs/srv/linear_track_back_origin.hpp>
-#include <xarm_msgs/srv/linear_motor_back_origin.hpp>
 #include <xarm_msgs/srv/linear_track_set_pos.hpp>
-#include <xarm_msgs/srv/linear_motor_set_pos.hpp>
 
 #endif // __XARM_MSGS_H

--- a/xarm_api/launch/_robot_driver.launch.py
+++ b/xarm_api/launch/_robot_driver.launch.py
@@ -55,7 +55,6 @@ def launch_setup(context, *args, **kwargs):
     dof = LaunchConfiguration('dof', default=7)
     hw_ns = LaunchConfiguration('hw_ns', default='xarm')
     add_gripper = LaunchConfiguration('add_gripper', default=False)
-    add_bio_gripper = LaunchConfiguration('add_bio_gripper', default=False)
     add_vacuum_gripper = LaunchConfiguration('add_vacuum_gripper', default=False)
     prefix = LaunchConfiguration('prefix', default='')
     baud_checkset = LaunchConfiguration('baud_checkset', default=True)
@@ -64,13 +63,11 @@ def launch_setup(context, *args, **kwargs):
     
     show_rviz = LaunchConfiguration('show_rviz', default=False)
     robot_type = LaunchConfiguration('robot_type', default='xarm')
-    extra_robot_api_params_path = LaunchConfiguration('extra_robot_api_params_path', default='')
     
     robot_params = generate_robot_api_params(
         os.path.join(get_package_share_directory('xarm_api'), 'config', 'xarm_params.yaml'),
         os.path.join(get_package_share_directory('xarm_api'), 'config', 'xarm_user_params.yaml'),
-        LaunchConfiguration('ros_namespace', default='').perform(context), node_name='ufactory_driver',
-        extra_robot_api_params_path=extra_robot_api_params_path.perform(context)
+        LaunchConfiguration('ros_namespace', default='').perform(context), node_name='ufactory_driver'
     )
     
     # robot driver node
@@ -88,7 +85,6 @@ def launch_setup(context, *args, **kwargs):
                 'report_type': report_type,
                 'dof': dof,
                 'add_gripper': add_gripper if robot_type.perform(context) != 'lite' else False,
-                'add_bio_gripper': add_bio_gripper,
                 'hw_ns': '{}{}'.format(prefix.perform(context).strip('/'), hw_ns.perform(context).strip('/')),
                 'prefix': prefix.perform(context).strip('/'),
                 'baud_checkset': baud_checkset,

--- a/xarm_api/src/xarm_driver.cpp
+++ b/xarm_api/src/xarm_driver.cpp
@@ -560,7 +560,7 @@ namespace xarm_api
         if (add_bio_gripper) {
             bio_gripper_init_loop_ = false;
             std::thread([this]() {
-                float cur_pos;
+                int cur_pos;
                 int ret = arm->get_bio_gripper_position(&cur_pos);
                 while (ret == 0 && !bio_gripper_init_loop_)
                 {
@@ -618,7 +618,7 @@ namespace xarm_api
         RCLCPP_INFO(node_->get_logger(), "bio_gripper_action_execute, position=%f, max_effort=%f", goal->command.position, goal->command.max_effort);
         
         int ret;
-        float cur_pos = 0;
+        int cur_pos = 0;
         int err = 0;
         ret = arm->get_bio_gripper_error(&err);
         if (ret != 0 || err != 0) {
@@ -646,7 +646,7 @@ namespace xarm_api
                 RCLCPP_ERROR(node_->get_logger(), "bio goal_handle canceled exception, ex=%s", e.what()); 
             }
             ret = arm->get_bio_gripper_error(&err);
-            RCLCPP_WARN(node_->get_logger(), "set_bio_gripper_enable, ret=%d, err=%d, cur_pos=%f", ret, err, cur_pos);
+            RCLCPP_WARN(node_->get_logger(), "set_bio_gripper_enable, ret=%d, err=%d, cur_pos=%d", ret, err, cur_pos);
             return;
         }
         ret = arm->set_bio_gripper_speed(bio_gripper_speed_);
@@ -658,7 +658,7 @@ namespace xarm_api
                 RCLCPP_ERROR(node_->get_logger(), "bio goal_handle canceled exception, ex=%s", e.what()); 
             }
             ret = arm->get_bio_gripper_error(&err);
-            RCLCPP_WARN(node_->get_logger(), "set_bio_gripper_speed, ret=%d, err=%d, cur_pos=%f", ret, err, cur_pos);
+            RCLCPP_WARN(node_->get_logger(), "set_bio_gripper_speed, ret=%d, err=%d, cur_pos=%d", ret, err, cur_pos);
             return;
         }
         float last_pos = -bio_gripper_max_pos_;
@@ -673,7 +673,7 @@ namespace xarm_api
                 ret2 = arm->close_bio_gripper(true, 5, false); // set wait_motion=false
             int err;
             arm->get_bio_gripper_error(&err);
-            RCLCPP_INFO(node_->get_logger(), "set_bio_gripper_position, ret=%d, err=%d, cur_pos=%f", ret2, err, cur_pos);
+            RCLCPP_INFO(node_->get_logger(), "set_bio_gripper_position, ret=%d, err=%d, cur_pos=%d", ret2, err, cur_pos);
             is_move = false;
         }).detach();
         int cnt = 0;
@@ -718,7 +718,7 @@ namespace xarm_api
             // }
         }
         arm->get_bio_gripper_position(&cur_pos);
-        RCLCPP_INFO(node_->get_logger(), "bio move finish, cur_pos=%f", cur_pos);
+        RCLCPP_INFO(node_->get_logger(), "bio move finish, cur_pos=%d", cur_pos);
         if (rclcpp::ok() && !is_succeed) {
             bio_gripper_result_->position = _bio_gripper_pos_convert(cur_pos);
             try {

--- a/xarm_api/src/xarm_driver.cpp
+++ b/xarm_api/src/xarm_driver.cpp
@@ -64,7 +64,7 @@ namespace xarm_api
         curr_mode = report_data_ptr->mode;
         curr_cmdnum = report_data_ptr->cmdnum;
 
-        rclcpp::Time now = node_->get_clock()->now();
+        rclcpp::Time now_ = node_->get_clock()->now();
         bool use_new = _firmware_version_is_ge(1, 8, 103);
         if (!use_new)
         {
@@ -94,11 +94,11 @@ namespace xarm_api
             xarm_state_msg_.pose[i] = report_data_ptr->pose[i];
             xarm_state_msg_.offset[i] = report_data_ptr->tcp_offset[i];
         }
-        xarm_state_msg_.header.stamp = now;
+        xarm_state_msg_.header.stamp = now_;
         pub_robot_msg(xarm_state_msg_);
 
         if (report_data_ptr->total_num >= 417) {
-            cgpio_state_msg_.header.stamp = now;
+            cgpio_state_msg_.header.stamp = now_;
             cgpio_state_msg_.state = report_data_ptr->cgpio_state;
             cgpio_state_msg_.code = report_data_ptr->cgpio_code;
             cgpio_state_msg_.input_digitals[0] = report_data_ptr->cgpio_input_digitals[0];
@@ -120,7 +120,7 @@ namespace xarm_api
 
         if ((report_type_ == "dev" && report_data_ptr->total_num >= 135) 
             || (report_type_ == "rich" && report_data_ptr->total_num >= 481)) {
-            ftsensor_msg_.header.stamp = now;
+            ftsensor_msg_.header.stamp = now_;
             ftsensor_msg_.header.frame_id = "uf_ft_sensor_ext_data";
             ftsensor_msg_.wrench.force.x = report_data_ptr->ft_ext_force[0];
             ftsensor_msg_.wrench.force.y = report_data_ptr->ft_ext_force[1];
@@ -168,11 +168,7 @@ namespace xarm_api
             }
         }
 
-        node_->get_parameter_or("joint_states.rate", joint_state_rate_, -1);
-        node_->get_parameter_or("joint_states.flags", joint_state_flags_, -1);
-        int rate = -1;
-        node_->get_parameter_or("joint_states_rate", rate, -1);
-        joint_state_rate_ = rate > 0 ? rate : joint_state_rate_;
+        node_->get_parameter_or("joint_states_rate", joint_states_rate_, -1);
 
         RCLCPP_INFO(node_->get_logger(), "robot_ip=%s, report_type=%s, dof=%d", server_ip.c_str(), report_type_.c_str(), dof_);
 
@@ -238,26 +234,19 @@ namespace xarm_api
         if (!in_ros_control_)
         {
             std::thread([this]() {
+                float cur_pos;
                 float position[7] = {0};
                 float velocity[7] = {0};
                 float effort[7] = {0};
-                if (joint_state_rate_ < 0) {
-                    joint_state_rate_ = report_type_ == "dev" ? 100 : 5;
+                if (joint_states_rate_ < 0) {
+                    joint_states_rate_ = report_type_ == "dev" ? 100 : 5;
                 }
                 bool use_new = _firmware_version_is_ge(1, 8, 103);
-                int microseconds = 1000000 / joint_state_rate_;
-
-                int num = 3;
-                if (_firmware_version_is_ge(2, 6, 107)) {
-                    if (joint_state_flags_ >= 0){
-                        num = ((joint_state_flags_ & 0x0F) << 4) + num;
-                    }
-                }
-
+                int microseconds = 1000000 / joint_states_rate_;
                 while (arm->is_connected())
                 {
                     if (use_new)
-                        arm->get_joint_states(position, velocity, effort, num);
+                        arm->get_joint_states(position, velocity, effort);
                     else
                         arm->get_servo_angle(position);
 
@@ -282,99 +271,6 @@ namespace xarm_api
         _init_subscription();
         _init_xarm_gripper();
         _init_bio_gripper();
-
-        bool add_gripper;
-        node_->get_parameter_or("add_gripper", add_gripper, false);
-
-        bool add_bio_gripper;
-        node_->get_parameter_or("add_bio_gripper", add_bio_gripper, false);
-
-        if (_firmware_version_is_ge(2, 7, 101) && (add_gripper || add_bio_gripper)) {
-            sock_rt_ = new SocketPort((char *)server_ip.data(), 30000, 10, 1024, 1);
-            std::thread([this]() {
-                int ret;
-                int size = 0;
-                unsigned char rx_data[1024];
-
-                // float target_joint_positions[7];
-                // float target_joint_velocities[7];
-                // float target_joint_accelerations[7];
-                // float actual_joint_positions[7];
-                // float actual_joint_velocities[7];
-                // float actual_joint_accelerations[7];
-                // float actual_joint_currents[7];
-                // float estimated_joint_torques[7];
-
-                // float ftsensor_raw_data[6];
-                // float ftsensor_filtered_data[6];
-
-                int dev_type = 0;
-                // int dev_status = 0;
-                int external_device_info[3];
-                int gripper_pulse;
-
-                while (arm->is_connected()) {
-                    if (sock_rt_->is_ok() != 0) {
-                        RCLCPP_ERROR(node_->get_logger(), "SocketPort 30000 disconnected!");
-                        break;
-                    }
-                    memset(rx_data, 0, 1024);
-                    ret = sock_rt_->read_frame(rx_data);
-                    if (ret != 0) continue;
-                    if (size == 0) size = bin8_to_32(rx_data + 4);
-                    unsigned char *data_fp = &rx_data[4];
-
-                    // hex_to_nfp32(data_fp + 32, target_joint_positions, 7);
-                    // hex_to_nfp32(data_fp + 60, target_joint_velocities, 7);
-                    // // hex_to_nfp32(data_fp + 88, target_joint_accelerations, 7);
-                    // hex_to_nfp32(data_fp + 116, actual_joint_positions, 7);
-                    // hex_to_nfp32(data_fp + 144, actual_joint_velocities, 7);
-                    // // hex_to_nfp32(data_fp + 172, actual_joint_accelerations, 7);
-                    // hex_to_nfp32(data_fp + 200, actual_joint_currents, 7);
-                    // hex_to_nfp32(data_fp + 118, estimated_joint_torques, 7);
-
-                    // hex_to_nfp32(data_fp + 688, ftsensor_raw_data, 6);
-                    // hex_to_nfp32(data_fp + 712, ftsensor_filtered_data, 6);
-
-                    dev_type = data_fp[736];
-                    // dev_status = data_fp[737];
-                    bin8_to_ns16(data_fp + 738, external_device_info, 3);
-
-                    // joint_state_msg_.header.stamp = node_->get_clock()->now();
-                    // for(int i = 0; i < dof_; i++)
-                    // {
-                    //     if (joint_state_flags_ & 0x01) {
-                    //         joint_state_msg_.position[i] = (double)target_joint_positions[i];
-                    //     }
-                    //     else {
-                    //         joint_state_msg_.position[i] = (double)actual_joint_positions[i];
-                    //     }
-                    //     if (joint_state_flags_ & 0x02) {
-                    //         joint_state_msg_.velocity[i] = (double)target_joint_velocities[i];
-                    //     }
-                    //     else {
-                    //         joint_state_msg_.velocity[i] = (double)actual_joint_velocities[i];
-                    //     }
-                    //     joint_state_msg_.effort[i] = (double)estimated_joint_torques[i];
-                    // }
-                    // pub_joint_state(joint_state_msg_);
-
-                    if (dev_type == 1 || dev_type == 2) {
-                        gripper_pulse = (int)((asin((external_device_info[0] - 16) / 110.0) * 57.29577951308232 + 8.33) * 18.28);
-                        _pub_xarm_gripper_joint_states(gripper_pulse);
-                    }
-                    else if (dev_type == 3) {
-                        // 注: 这里是mm
-                        _pub_bio_gripper_joint_states(external_device_info[0]);
-                    }
-
-                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-                }
-            }).detach();
-        }
-        else {
-            sock_rt_ = NULL;
-        }
     }
 
     bool XArmDriver::_firmware_version_is_ge(int major, int minor, int revision)
@@ -407,52 +303,6 @@ namespace xarm_api
         return &joint_state_msg_;
     }
 
-    int XArmDriver::update_joint_states(bool initialized, int flag)
-    {
-        static rclcpp::Time prev_time;
-        static rclcpp::Time curr_time;
-        static float prev_position[7] = {0};
-        static float curr_position[7] = {0};
-        static float curr_velocity[7] = {0};
-        static float curr_effort[7] = {0};
-
-        int num = 3;
-        if (_firmware_version_is_ge(2, 6, 107)) {
-            if (flag >= 0) {
-                num = ((flag & 0x0F) << 4) + num;
-            }
-            else if (joint_state_flags_ >= 0){
-                num = ((joint_state_flags_ & 0x0F) << 4) + num;
-            }
-        }
-
-        bool use_new = _firmware_version_is_ge(1, 8, 103);
-        int ret;
-        if (use_new)
-            ret = arm->get_joint_states(curr_position, curr_velocity, curr_effort, num);
-        else
-            ret = arm->get_servo_angle(curr_position);
-        curr_time = node_->get_clock()->now();
-
-        joint_state_msg_.header.stamp = curr_time;
-        for(int i = 0; i < joint_state_msg_.position.size(); i++)
-        {
-            joint_state_msg_.position[i] = (double)curr_position[i];
-            if (use_new) {
-                joint_state_msg_.velocity[i] = (double)curr_velocity[i];
-                joint_state_msg_.effort[i] = (double)curr_effort[i];
-            }
-            else {
-                curr_velocity[i] = !initialized ? 0.0 : (curr_position[i] - prev_position[i]) / (curr_time.seconds() - prev_time.seconds());
-                joint_state_msg_.velocity[i] = (double)curr_velocity[i];
-            }
-        }
-        pub_joint_state(joint_state_msg_);
-        memcpy(prev_position, curr_position, sizeof(float) * 7);
-        prev_time = curr_time;
-        return ret;
-    }
-
     void XArmDriver::_init_xarm_gripper(void)
     {
         node_->get_parameter_or("xarm_gripper.speed", xarm_gripper_speed_, 2000);  // 机械爪速度
@@ -466,7 +316,7 @@ namespace xarm_api
         xarm_gripper_feedback_ = std::make_shared<control_msgs::action::GripperCommand::Feedback>();
         xarm_gripper_result_ = std::make_shared<control_msgs::action::GripperCommand::Result>();;
         xarm_gripper_joint_state_msg_.header.stamp = node_->get_clock()->now();
-        xarm_gripper_joint_state_msg_.header.frame_id = "xarm-gripper-joint-state data";        
+        xarm_gripper_joint_state_msg_.header.frame_id = "gripper-joint-state data";        
         xarm_gripper_joint_state_msg_.name.resize(6);
         xarm_gripper_joint_state_msg_.position.resize(6, std::numeric_limits<double>::quiet_NaN());
         xarm_gripper_joint_state_msg_.velocity.resize(6, std::numeric_limits<double>::quiet_NaN());
@@ -493,12 +343,12 @@ namespace xarm_api
         if (add_gripper) {
             xarm_gripper_init_loop_ = false;
             std::thread([this]() {
-                int curr_pos;
-                int ret = arm->get_gripper_position(&curr_pos);
+                float cur_pos;
+                int ret = arm->get_gripper_position(&cur_pos);
                 while (ret == 0 && !xarm_gripper_init_loop_)
                 {
                     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-                    _pub_xarm_gripper_joint_states(curr_pos);
+                    _pub_xarm_gripper_joint_states(cur_pos);
                 }
             }).detach();
         }
@@ -507,14 +357,14 @@ namespace xarm_api
     inline float XArmDriver::_xarm_gripper_pos_convert(float pos, bool reversed)
     {
         if (reversed) {
-            return fabs(xarm_gripper_max_pos_ - pos * 1000.0);
+            return fabs(xarm_gripper_max_pos_ - pos * 1000);
         }
         else {
-            return fabs(xarm_gripper_max_pos_ - pos) / 1000.0;
+            return fabs(xarm_gripper_max_pos_ - pos) / 1000;
         }
     }
 
-    void XArmDriver::_pub_xarm_gripper_joint_states(int pos)
+    void XArmDriver::_pub_xarm_gripper_joint_states(float pos)
     {
         xarm_gripper_joint_state_msg_.header.stamp = node_->get_clock()->now();
         float p = _xarm_gripper_pos_convert(pos);
@@ -552,7 +402,7 @@ namespace xarm_api
         RCLCPP_INFO(node_->get_logger(), "gripper_action_execute, position=%f, max_effort=%f", goal->command.position, goal->command.max_effort);
         
         int ret;
-        int curr_pos = 0;
+        float cur_pos = 0;
         int err = 0;
         ret = arm->get_gripper_err_code(&err);
         if (ret != 0 || err != 0) {
@@ -564,54 +414,54 @@ namespace xarm_api
             RCLCPP_ERROR(node_->get_logger(), "get_gripper_err_code, ret=%d, err=%d", ret, err);
             return;
         }
-        ret = arm->get_gripper_position(&curr_pos);
-        _pub_xarm_gripper_joint_states(curr_pos);
+        ret = arm->get_gripper_position(&cur_pos);
+        _pub_xarm_gripper_joint_states(cur_pos);
 
         ret = arm->set_gripper_mode(0);
         if (ret != 0) {
-            xarm_gripper_result_->position = _xarm_gripper_pos_convert(curr_pos);
+            xarm_gripper_result_->position = _xarm_gripper_pos_convert(cur_pos);
             try {
                 goal_handle->canceled(xarm_gripper_result_);
             } catch (std::exception &e) {
                 RCLCPP_ERROR(node_->get_logger(), "goal_handle canceled exception, ex=%s", e.what()); 
             }
             ret = arm->get_gripper_err_code(&err);
-            RCLCPP_WARN(node_->get_logger(), "set_gripper_mode, ret=%d, err=%d, curr_pos=%d", ret, err, curr_pos);
+            RCLCPP_WARN(node_->get_logger(), "set_gripper_mode, ret=%d, err=%d, cur_pos=%f", ret, err, cur_pos);
             return;
         }
         ret = arm->set_gripper_enable(true);
         if (ret != 0) {
-            xarm_gripper_result_->position = _xarm_gripper_pos_convert(curr_pos);
+            xarm_gripper_result_->position = _xarm_gripper_pos_convert(cur_pos);
             try {
                 goal_handle->canceled(xarm_gripper_result_);
             } catch (std::exception &e) {
                 RCLCPP_ERROR(node_->get_logger(), "goal_handle canceled exception, ex=%s", e.what()); 
             }
             ret = arm->get_gripper_err_code(&err);
-            RCLCPP_WARN(node_->get_logger(), "set_gripper_enable, ret=%d, err=%d, curr_pos=%d", ret, err, curr_pos);
+            RCLCPP_WARN(node_->get_logger(), "set_gripper_enable, ret=%d, err=%d, cur_pos=%f", ret, err, cur_pos);
             return;
         }
         ret = arm->set_gripper_speed(xarm_gripper_speed_);
         if (ret != 0) {
-            xarm_gripper_result_->position = _xarm_gripper_pos_convert(curr_pos);
+            xarm_gripper_result_->position = _xarm_gripper_pos_convert(cur_pos);
             try {
                 goal_handle->canceled(xarm_gripper_result_);
             } catch (std::exception &e) {
                 RCLCPP_ERROR(node_->get_logger(), "goal_handle canceled exception, ex=%s", e.what()); 
             }
             ret = arm->get_gripper_err_code(&err);
-            RCLCPP_WARN(node_->get_logger(), "set_gripper_speed, ret=%d, err=%d, curr_pos=%d", ret, err, curr_pos);
+            RCLCPP_WARN(node_->get_logger(), "set_gripper_speed, ret=%d, err=%d, cur_pos=%f", ret, err, cur_pos);
             return;
         }
-        int last_pos = -xarm_gripper_max_pos_;
+        float last_pos = -xarm_gripper_max_pos_;
         float target_pos = _xarm_gripper_pos_convert(goal->command.position, true);
         bool is_move = true;
-        std::thread([this, &target_pos, &is_move, &curr_pos]() {
+        std::thread([this, &target_pos, &is_move, &cur_pos]() {
             is_move = true;
-            int ret2 = arm->set_gripper_position((int)target_pos, true, -1, false); // set wait_motion=false
+            int ret2 = arm->set_gripper_position(target_pos, true, -1, false); // set wait_motion=false
             int err;
             arm->get_gripper_err_code(&err);
-            RCLCPP_INFO(node_->get_logger(), "set_gripper_position, ret=%d, err=%d, curr_pos=%d", ret2, err, curr_pos);
+            RCLCPP_INFO(node_->get_logger(), "set_gripper_position, ret=%d, err=%d, cur_pos=%f", ret2, err, cur_pos);
             is_move = false;
         }).detach();
         int cnt = 0;
@@ -620,13 +470,13 @@ namespace xarm_api
         while (is_move && rclcpp::ok())
         {
             std::this_thread::sleep_for(sltime);
-            ret = arm->get_gripper_position(&curr_pos);
+            ret = arm->get_gripper_position(&cur_pos);
             if (ret == 0) {
                 if (!is_succeed) {
-                    if (fabs(last_pos - curr_pos) < xarm_gripper_threshold_) {
+                    if (fabs(last_pos - cur_pos) < xarm_gripper_threshold_) {
                         cnt += 1;
-                        if (cnt >= xarm_gripper_threshold_times_ && fabs(target_pos - curr_pos) < 15) {
-                            xarm_gripper_result_->position = _xarm_gripper_pos_convert(curr_pos);
+                        if (cnt >= xarm_gripper_threshold_times_ && fabs(target_pos - cur_pos) < 15) {
+                            xarm_gripper_result_->position = _xarm_gripper_pos_convert(cur_pos);
                             try {
                                 goal_handle->succeed(xarm_gripper_result_);
                             } catch (std::exception &e) {
@@ -637,28 +487,28 @@ namespace xarm_api
                     }
                     else {
                         cnt = 0;
-                        last_pos = curr_pos;
+                        last_pos = cur_pos;
                     }
                 }
-                xarm_gripper_feedback_->position = _xarm_gripper_pos_convert(curr_pos);
+                xarm_gripper_feedback_->position = _xarm_gripper_pos_convert(cur_pos);
                 try {
                     goal_handle->publish_feedback(xarm_gripper_feedback_);
                 } catch (std::exception &e) {
                     RCLCPP_ERROR(node_->get_logger(), "goal_handle publish_feedback exception, ex=%s", e.what());
                 }
-                _pub_xarm_gripper_joint_states(curr_pos);
+                _pub_xarm_gripper_joint_states(cur_pos);
             }
             // if (goal_handle->is_canceling()) {
-            //     xarm_gripper_result_->position = _xarm_gripper_pos_convert(curr_pos);
+            //     xarm_gripper_result_->position = _xarm_gripper_pos_convert(cur_pos);
             //     goal_handle->canceled(xarm_gripper_result_);
-            //     RCLCPP_INFO(this->get_logger(), "Goal canceled, curr_pos=%d", curr_pos);
+            //     RCLCPP_INFO(this->get_logger(), "Goal canceled, cur_pos=%f", cur_pos);
             //     return;
             // }
         }
-        arm->get_gripper_position(&curr_pos);
-        RCLCPP_INFO(node_->get_logger(), "move finish, curr_pos=%d", curr_pos);
+        arm->get_gripper_position(&cur_pos);
+        RCLCPP_INFO(node_->get_logger(), "move finish, cur_pos=%f", cur_pos);
         if (rclcpp::ok() && !is_succeed) {
-            xarm_gripper_result_->position = _xarm_gripper_pos_convert(curr_pos);
+            xarm_gripper_result_->position = _xarm_gripper_pos_convert(cur_pos);
             try {
                 goal_handle->succeed(xarm_gripper_result_);
             } catch (std::exception &e) {
@@ -671,12 +521,12 @@ namespace xarm_api
 
     void XArmDriver::_init_bio_gripper(void)
     {
-        node_->get_parameter_or("bio_gripper.speed", bio_gripper_speed_, 2000);  // BIO机械爪速度
-        node_->get_parameter_or("bio_gripper.max_pos", bio_gripper_max_pos_, 150); // BIO机械爪最大值，用来转换
-        node_->get_parameter_or("bio_gripper.min_pos", bio_gripper_min_pos_, 71); // BIO机械爪最小值，用来转换
-        node_->get_parameter_or("bio_gripper.frequency", bio_gripper_frequency_, 10); // 发送BIO机械爪位置后查询机械爪位置的频率
-        node_->get_parameter_or("bio_gripper.threshold", bio_gripper_threshold_, 3); // 检测BIO机械爪当前位置和上一次位置的差值如果小于当前值，则认为机械爪没动
-        node_->get_parameter_or("bio_gripper.threshold_times", bio_gripper_threshold_times_, 10); // 如果检测到BIO机械爪没动的次数超过此值且当前位置和目标位置差值不超过15，则认为机械爪运动成功
+        node_->get_parameter_or("bio_gripper.speed", bio_gripper_speed_, 2000);  // 机械爪速度
+        node_->get_parameter_or("bio_gripper.max_pos", bio_gripper_max_pos_, 130); // 机械爪最大值，用来转换
+        node_->get_parameter_or("bio_gripper.min_pos", bio_gripper_min_pos_, 50); // 机械爪最大值，用来转换
+        node_->get_parameter_or("bio_gripper.frequency", bio_gripper_frequency_, 10); // 发送机械爪位置后查询机械爪位置的频率
+        node_->get_parameter_or("bio_gripper.threshold", bio_gripper_threshold_, 3); // 检测机械爪当前位置和上一次位置的差值如果小于当前值，则认为机械爪没动
+        node_->get_parameter_or("bio_gripper.threshold_times", bio_gripper_threshold_times_, 10); // 如果检测到机械爪没动的次数超过此值且当前位置和目标位置差值不超过15，则认为机械爪运动成功
         RCLCPP_INFO(node_->get_logger(), "bio_gripper_speed: %d, bio_gripper_max_pos: %d, bio_gripper_min_pos: %d, bio_gripper_frequency : %d, bio_gripper_threshold: %d, bio_gripper_threshold_times: %d", 
             bio_gripper_speed_, bio_gripper_max_pos_, bio_gripper_min_pos_, bio_gripper_frequency_, bio_gripper_threshold_, bio_gripper_threshold_times_);
 
@@ -710,12 +560,12 @@ namespace xarm_api
         if (add_bio_gripper) {
             bio_gripper_init_loop_ = false;
             std::thread([this]() {
-                int curr_pos;
-                int ret = arm->get_bio_gripper_position(&curr_pos);
+                float cur_pos;
+                int ret = arm->get_bio_gripper_position(&cur_pos);
                 while (ret == 0 && !bio_gripper_init_loop_)
                 {
                     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-                    _pub_bio_gripper_joint_states(curr_pos);
+                    _pub_bio_gripper_joint_states(cur_pos);
                 }
             }).detach();
         }
@@ -724,14 +574,14 @@ namespace xarm_api
     inline float XArmDriver::_bio_gripper_pos_convert(float pos, bool reversed)
     {
         if (reversed) {
-            return fabs(pos * 1000 * 2 + 71);
+            return fabs(pos * 1000 * 2 + 50);
         }
         else {
-            return -fabs(pos - 71) / 1000 / 2;
+            return -fabs(pos - 50) / 1000 / 2;
         }
     }
 
-    void XArmDriver::_pub_bio_gripper_joint_states(int pos)
+    void XArmDriver::_pub_bio_gripper_joint_states(float pos)
     {
         bio_gripper_joint_state_msg_.header.stamp = node_->get_clock()->now();
         float p = _bio_gripper_pos_convert(pos);
@@ -768,7 +618,7 @@ namespace xarm_api
         RCLCPP_INFO(node_->get_logger(), "bio_gripper_action_execute, position=%f, max_effort=%f", goal->command.position, goal->command.max_effort);
         
         int ret;
-        int curr_pos = 0;
+        float cur_pos = 0;
         int err = 0;
         ret = arm->get_bio_gripper_error(&err);
         if (ret != 0 || err != 0) {
@@ -784,46 +634,46 @@ namespace xarm_api
             RCLCPP_ERROR(node_->get_logger(), "get_bio_gripper_error, ret=%d, err=%d", ret, err);
             return;
         }
-        ret = arm->get_bio_gripper_position(&curr_pos);
-        _pub_bio_gripper_joint_states(curr_pos);
+        ret = arm->get_bio_gripper_position(&cur_pos);
+        _pub_bio_gripper_joint_states(cur_pos);
 
-        // ret = arm->set_bio_gripper_enable(true);
-        // if (ret != 0) {
-        //     bio_gripper_result_->position = _bio_gripper_pos_convert(curr_pos);
-        //     try {
-        //         goal_handle->canceled(bio_gripper_result_);
-        //     } catch (std::exception &e) {
-        //         RCLCPP_ERROR(node_->get_logger(), "bio goal_handle canceled exception, ex=%s", e.what()); 
-        //     }
-        //     ret = arm->get_bio_gripper_error(&err);
-        //     RCLCPP_WARN(node_->get_logger(), "set_bio_gripper_enable, ret=%d, err=%d, curr_pos=%d", ret, err, curr_pos);
-        //     return;
-        // }
-        // ret = arm->set_bio_gripper_speed(bio_gripper_speed_);
-        // if (ret != 0) {
-        //     bio_gripper_result_->position = _bio_gripper_pos_convert(curr_pos);
-        //     try {
-        //         goal_handle->canceled(bio_gripper_result_);
-        //     } catch (std::exception &e) {
-        //         RCLCPP_ERROR(node_->get_logger(), "bio goal_handle canceled exception, ex=%s", e.what()); 
-        //     }
-        //     ret = arm->get_bio_gripper_error(&err);
-        //     RCLCPP_WARN(node_->get_logger(), "set_bio_gripper_speed, ret=%d, err=%d, curr_pos=%d", ret, err, curr_pos);
-        //     return;
-        // }
-        int last_pos = -bio_gripper_max_pos_;
+        ret = arm->set_bio_gripper_enable(true);
+        if (ret != 0) {
+            bio_gripper_result_->position = _bio_gripper_pos_convert(cur_pos);
+            try {
+                goal_handle->canceled(bio_gripper_result_);
+            } catch (std::exception &e) {
+                RCLCPP_ERROR(node_->get_logger(), "bio goal_handle canceled exception, ex=%s", e.what()); 
+            }
+            ret = arm->get_bio_gripper_error(&err);
+            RCLCPP_WARN(node_->get_logger(), "set_bio_gripper_enable, ret=%d, err=%d, cur_pos=%f", ret, err, cur_pos);
+            return;
+        }
+        ret = arm->set_bio_gripper_speed(bio_gripper_speed_);
+        if (ret != 0) {
+            bio_gripper_result_->position = _bio_gripper_pos_convert(cur_pos);
+            try {
+                goal_handle->canceled(bio_gripper_result_);
+            } catch (std::exception &e) {
+                RCLCPP_ERROR(node_->get_logger(), "bio goal_handle canceled exception, ex=%s", e.what()); 
+            }
+            ret = arm->get_bio_gripper_error(&err);
+            RCLCPP_WARN(node_->get_logger(), "set_bio_gripper_speed, ret=%d, err=%d, cur_pos=%f", ret, err, cur_pos);
+            return;
+        }
+        float last_pos = -bio_gripper_max_pos_;
         float target_pos = _bio_gripper_pos_convert(goal->command.position, true);
         bool is_move = true;
-        std::thread([this, &target_pos, &is_move, &curr_pos]() {
+        std::thread([this, &target_pos, &is_move, &cur_pos]() {
             is_move = true;
             int ret2;
             if (target_pos >= 100)
-                ret2 = arm->open_bio_gripper(bio_gripper_speed_, true, 5, false); // set wait_motion=false
+                ret2 = arm->open_bio_gripper(true, 5, false); // set wait_motion=false
             else
-                ret2 = arm->close_bio_gripper(bio_gripper_speed_, true, 5, false); // set wait_motion=false
+                ret2 = arm->close_bio_gripper(true, 5, false); // set wait_motion=false
             int err;
             arm->get_bio_gripper_error(&err);
-            RCLCPP_INFO(node_->get_logger(), "set_bio_gripper_position, ret=%d, err=%d, curr_pos=%d", ret2, err, curr_pos);
+            RCLCPP_INFO(node_->get_logger(), "set_bio_gripper_position, ret=%d, err=%d, cur_pos=%f", ret2, err, cur_pos);
             is_move = false;
         }).detach();
         int cnt = 0;
@@ -832,13 +682,13 @@ namespace xarm_api
         while (is_move && rclcpp::ok())
         {
             std::this_thread::sleep_for(sltime);
-            ret = arm->get_bio_gripper_position(&curr_pos);
+            ret = arm->get_bio_gripper_position(&cur_pos);
             if (ret == 0) {
                 if (!is_succeed) {
-                    if (fabs(last_pos - curr_pos) < bio_gripper_threshold_) {
+                    if (fabs(last_pos - cur_pos) < bio_gripper_threshold_) {
                         cnt += 1;
-                        if (cnt >= bio_gripper_threshold_times_ && fabs(target_pos - curr_pos) < 15) {
-                            bio_gripper_result_->position = _bio_gripper_pos_convert(curr_pos);
+                        if (cnt >= bio_gripper_threshold_times_ && fabs(target_pos - cur_pos) < 15) {
+                            bio_gripper_result_->position = _bio_gripper_pos_convert(cur_pos);
                             try {
                                 goal_handle->succeed(bio_gripper_result_);
                             } catch (std::exception &e) {
@@ -849,28 +699,28 @@ namespace xarm_api
                     }
                     else {
                         cnt = 0;
-                        last_pos = curr_pos;
+                        last_pos = cur_pos;
                     }
                 }
-                bio_gripper_feedback_->position = _bio_gripper_pos_convert(curr_pos);
+                bio_gripper_feedback_->position = _bio_gripper_pos_convert(cur_pos);
                 try {
                     goal_handle->publish_feedback(bio_gripper_feedback_);
                 } catch (std::exception &e) {
                     RCLCPP_ERROR(node_->get_logger(), "bio goal_handle publish_feedback exception, ex=%s", e.what());
                 }
-                _pub_bio_gripper_joint_states(curr_pos);
+                _pub_bio_gripper_joint_states(cur_pos);
             }
             // if (goal_handle->is_canceling()) {
-            //     bio_gripper_result_->position = _bio_gripper_pos_convert(curr_pos);
+            //     bio_gripper_result_->position = _bio_gripper_pos_convert(cur_pos);
             //     goal_handle->canceled(bio_gripper_result_);
-            //     RCLCPP_INFO(this->get_logger(), "Goal canceled, curr_pos=%d", curr_pos);
+            //     RCLCPP_INFO(this->get_logger(), "Goal canceled, cur_pos=%f", cur_pos);
             //     return;
             // }
         }
-        arm->get_bio_gripper_position(&curr_pos);
-        RCLCPP_INFO(node_->get_logger(), "bio move finish, curr_pos=%d", curr_pos);
+        arm->get_bio_gripper_position(&cur_pos);
+        RCLCPP_INFO(node_->get_logger(), "bio move finish, cur_pos=%f", cur_pos);
         if (rclcpp::ok() && !is_succeed) {
-            bio_gripper_result_->position = _bio_gripper_pos_convert(curr_pos);
+            bio_gripper_result_->position = _bio_gripper_pos_convert(cur_pos);
             try {
                 goal_handle->succeed(bio_gripper_result_);
             } catch (std::exception &e) {

--- a/xarm_api/src/xarm_driver_service.cpp
+++ b/xarm_api/src/xarm_driver_service.cpp
@@ -54,16 +54,12 @@ namespace xarm_api
         service_clean_bio_gripper_error_ = _create_service<xarm_msgs::srv::Call>("clean_bio_gripper_error", &XArmDriver::_clean_bio_gripper_error);
         service_start_record_trajectory_ = _create_service<xarm_msgs::srv::Call>("start_record_trajectory", &XArmDriver::_start_record_trajectory);
         service_stop_record_trajectory_ = _create_service<xarm_msgs::srv::Call>("stop_record_trajectory", &XArmDriver::_stop_record_trajectory);
-        service_set_ft_sensor_zero_ = _create_service<xarm_msgs::srv::Call>("set_ft_sensor_zero", &XArmDriver::_set_ft_sensor_zero);
-        service_set_linear_motor_stop_ = _create_service<xarm_msgs::srv::Call>("set_linear_motor_stop", &XArmDriver::_set_linear_motor_stop);
-        service_clean_linear_motor_error_ = _create_service<xarm_msgs::srv::Call>("clean_linear_motor_error", &XArmDriver::_clean_linear_motor_error);
+        service_ft_sensor_set_zero_ = _create_service<xarm_msgs::srv::Call>("ft_sensor_set_zero", &XArmDriver::_ft_sensor_set_zero);
+        service_set_linear_track_stop_ = _create_service<xarm_msgs::srv::Call>("set_linear_track_stop", &XArmDriver::_set_linear_track_stop);
+        service_clean_linear_track_error_ = _create_service<xarm_msgs::srv::Call>("clean_linear_track_error", &XArmDriver::_clean_linear_track_error);
         service_open_lite6_gripper_ = _create_service<xarm_msgs::srv::Call>("open_lite6_gripper", &XArmDriver::_open_lite6_gripper);
         service_close_lite6_gripper_ = _create_service<xarm_msgs::srv::Call>("close_lite6_gripper", &XArmDriver::_close_lite6_gripper);
         service_stop_lite6_gripper_ = _create_service<xarm_msgs::srv::Call>("stop_lite6_gripper", &XArmDriver::_stop_lite6_gripper);
-        // OLD SERVICE
-        service_ft_sensor_set_zero_ = _create_service<xarm_msgs::srv::Call>("ft_sensor_set_zero", &XArmDriver::_set_ft_sensor_zero);
-        service_set_linear_track_stop_ = _create_service<xarm_msgs::srv::Call>("set_linear_track_stop", &XArmDriver::_set_linear_motor_stop);
-        service_clean_linear_track_error_ = _create_service<xarm_msgs::srv::Call>("clean_linear_track_error", &XArmDriver::_clean_linear_motor_error);
 
         // GetInt16
         service_get_state_ = _create_service<xarm_msgs::srv::GetInt16>("get_state", &XArmDriver::_get_state);
@@ -74,29 +70,19 @@ namespace xarm_api
         service_get_bio_gripper_error_ = _create_service<xarm_msgs::srv::GetInt16>("get_bio_gripper_error", &XArmDriver::_get_bio_gripper_error);
         service_get_reduced_mode_ = _create_service<xarm_msgs::srv::GetInt16>("get_reduced_mode", &XArmDriver::_get_reduced_mode);
         service_get_report_tau_or_i_ = _create_service<xarm_msgs::srv::GetInt16>("get_report_tau_or_i", &XArmDriver::_get_report_tau_or_i);
-        service_get_ft_sensor_mode_ = _create_service<xarm_msgs::srv::GetInt16>("get_ft_sensor_mode", &XArmDriver::_get_ft_sensor_mode);
+        service_ft_sensor_app_get_ = _create_service<xarm_msgs::srv::GetInt16>("ft_sensor_app_get", &XArmDriver::_ft_sensor_app_get);
         service_get_ft_sensor_error_ = _create_service<xarm_msgs::srv::GetInt16>("get_ft_sensor_error", &XArmDriver::_get_ft_sensor_error);
         service_get_trajectory_rw_status_ = _create_service<xarm_msgs::srv::GetInt16>("get_trajectory_rw_status", &XArmDriver::_get_trajectory_rw_status);
-        service_get_linear_motor_pos_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_motor_pos", &XArmDriver::_get_linear_motor_pos);
-        service_get_linear_motor_status_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_motor_status", &XArmDriver::_get_linear_motor_status);
-        service_get_linear_motor_error_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_motor_error", &XArmDriver::_get_linear_motor_error);
-        service_get_linear_motor_is_enabled_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_motor_is_enabled", &XArmDriver::_get_linear_motor_is_enabled);
-        service_get_linear_motor_on_zero_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_motor_on_zero", &XArmDriver::_get_linear_motor_on_zero);
-        service_get_linear_motor_sci_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_motor_sci", &XArmDriver::_get_linear_motor_sci);
-        // OLD SERVICE
-        service_ft_sensor_app_get_ = _create_service<xarm_msgs::srv::GetInt16>("ft_sensor_app_get", &XArmDriver::_get_ft_sensor_mode);
-        service_get_linear_track_pos_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_pos", &XArmDriver::_get_linear_motor_pos);
-        service_get_linear_track_status_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_status", &XArmDriver::_get_linear_motor_status);
-        service_get_linear_track_error_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_error", &XArmDriver::_get_linear_motor_error);
-        service_get_linear_track_is_enabled_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_is_enabled", &XArmDriver::_get_linear_motor_is_enabled);
-        service_get_linear_track_on_zero_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_on_zero", &XArmDriver::_get_linear_motor_on_zero);
-        service_get_linear_track_sci_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_sci", &XArmDriver::_get_linear_motor_sci);
+        service_get_linear_track_pos_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_pos", &XArmDriver::_get_linear_track_pos);
+        service_get_linear_track_status_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_status", &XArmDriver::_get_linear_track_status);
+        service_get_linear_track_error_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_error", &XArmDriver::_get_linear_track_error);
+        service_get_linear_track_is_enabled_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_is_enabled", &XArmDriver::_get_linear_track_is_enabled);
+        service_get_linear_track_on_zero_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_on_zero", &XArmDriver::_get_linear_track_on_zero);
+        service_get_linear_track_sci_ = _create_service<xarm_msgs::srv::GetInt16>("get_linear_track_sci", &XArmDriver::_get_linear_track_sci);
 
         // GetInt16List
         service_get_err_warn_code_ = _create_service<xarm_msgs::srv::GetInt16List>("get_err_warn_code", &XArmDriver::_get_err_warn_code);
-        service_get_linear_motor_sco_ = _create_service<xarm_msgs::srv::GetInt16List>("get_linear_motor_sco", &XArmDriver::_get_linear_motor_sco);
-        // OLD SERVICE
-        service_get_linear_track_sco_ = _create_service<xarm_msgs::srv::GetInt16List>("get_linear_track_sco", &XArmDriver::_get_linear_motor_sco);
+        service_get_linear_track_sco_ = _create_service<xarm_msgs::srv::GetInt16List>("get_linear_track_sco", &XArmDriver::_get_linear_track_sco);
 
         // SetInt16
         service_set_mode_ = _create_service<xarm_msgs::srv::SetInt16>("set_mode", &XArmDriver::_set_mode);
@@ -113,21 +99,15 @@ namespace xarm_api
         service_set_simulation_robot_ = _create_service<xarm_msgs::srv::SetInt16>("set_simulation_robot", &XArmDriver::_set_simulation_robot);
         service_set_baud_checkset_enable_ = _create_service<xarm_msgs::srv::SetInt16>("set_baud_checkset_enable", &XArmDriver::_set_baud_checkset_enable);
         service_set_report_tau_or_i_ = _create_service<xarm_msgs::srv::SetInt16>("set_report_tau_or_i", &XArmDriver::_set_report_tau_or_i);
-        service_set_ft_sensor_enable_ = _create_service<xarm_msgs::srv::SetInt16>("set_ft_sensor_enable", &XArmDriver::_set_ft_sensor_enable);
-        service_set_ft_sensor_mode_ = _create_service<xarm_msgs::srv::SetInt16>("set_ft_sensor_mode", &XArmDriver::_set_ft_sensor_mode);
-        service_set_linear_motor_enable_ = _create_service<xarm_msgs::srv::SetInt16>("set_linear_motor_enable", &XArmDriver::_set_linear_motor_enable);
-        service_set_linear_motor_speed_ = _create_service<xarm_msgs::srv::SetInt16>("set_linear_motor_speed", &XArmDriver::_set_linear_motor_speed);
+        service_ft_sensor_enable_ = _create_service<xarm_msgs::srv::SetInt16>("ft_sensor_enable", &XArmDriver::_ft_sensor_enable);
+        service_ft_sensor_app_set_ = _create_service<xarm_msgs::srv::SetInt16>("ft_sensor_app_set", &XArmDriver::_ft_sensor_app_set);
+        service_set_linear_track_enable_ = _create_service<xarm_msgs::srv::SetInt16>("set_linear_track_enable", &XArmDriver::_set_linear_track_enable);
+        service_set_linear_track_speed_ = _create_service<xarm_msgs::srv::SetInt16>("set_linear_track_speed", &XArmDriver::_set_linear_track_speed);
         service_set_cartesian_velo_continuous_ = _create_service<xarm_msgs::srv::SetInt16>("set_cartesian_velo_continuous", &XArmDriver::_set_cartesian_velo_continuous);
         service_set_allow_approx_motion_ = _create_service<xarm_msgs::srv::SetInt16>("set_allow_approx_motion", &XArmDriver::_set_allow_approx_motion);
         service_set_only_check_type_ = _create_service<xarm_msgs::srv::SetInt16>("set_only_check_type", &XArmDriver::_set_only_check_type);
         service_config_tgpio_reset_when_stop_ = _create_service<xarm_msgs::srv::SetInt16>("config_tgpio_reset_when_stop", &XArmDriver::_config_tgpio_reset_when_stop);
         service_config_cgpio_reset_when_stop_ = _create_service<xarm_msgs::srv::SetInt16>("config_cgpio_reset_when_stop", &XArmDriver::_config_cgpio_reset_when_stop);
-        service_set_rs485_use_503_port_ = _create_service<xarm_msgs::srv::SetInt16>("set_rs485_use_503_port", &XArmDriver::_set_rs485_use_503_port);
-        // OLD SERVICE
-        service_ft_sensor_enable_ = _create_service<xarm_msgs::srv::SetInt16>("ft_sensor_enable", &XArmDriver::_set_ft_sensor_enable);
-        service_ft_sensor_app_set_ = _create_service<xarm_msgs::srv::SetInt16>("ft_sensor_app_set", &XArmDriver::_set_ft_sensor_mode);
-        service_set_linear_track_enable_ = _create_service<xarm_msgs::srv::SetInt16>("set_linear_track_enable", &XArmDriver::_set_linear_motor_enable);
-        service_set_linear_track_speed_ = _create_service<xarm_msgs::srv::SetInt16>("set_linear_track_speed", &XArmDriver::_set_linear_motor_speed);
 
         // SetInt16ById
         service_motion_enable_= _create_service<xarm_msgs::srv::SetInt16ById>("motion_enable", &XArmDriver::_motion_enable);
@@ -136,7 +116,6 @@ namespace xarm_api
         
         // SetInt16List        
         service_set_reduced_tcp_boundary_ = _create_service<xarm_msgs::srv::SetInt16List>("set_reduced_tcp_boundary", &XArmDriver::_set_reduced_tcp_boundary);
-        service_set_external_device_monitor_params_ = _create_service<xarm_msgs::srv::SetInt16List>("set_external_device_monitor_params", &XArmDriver::_set_external_device_monitor_params);
 
         // GetInt32
         service_get_tgpio_modbus_baudrate_ = _create_service<xarm_msgs::srv::GetInt32>("get_tgpio_modbus_baudrate", &XArmDriver::_get_tgpio_modbus_baudrate);
@@ -259,42 +238,26 @@ namespace xarm_api
 
         // IdenLoad
         service_iden_tcp_load_ = _create_service<xarm_msgs::srv::IdenLoad>("iden_tcp_load", &XArmDriver::_iden_tcp_load);
-        service_iden_ft_sensor_load_offset_ = _create_service<xarm_msgs::srv::IdenLoad>("iden_ft_sensor_load_offset", &XArmDriver::_iden_ft_sensor_load_offset);
-        // OLD SERVICE
-        service_ft_sensor_iden_load_ = _create_service<xarm_msgs::srv::IdenLoad>("ft_sensor_iden_load", &XArmDriver::_iden_ft_sensor_load_offset);
+        service_ft_sensor_iden_load_ = _create_service<xarm_msgs::srv::IdenLoad>("ft_sensor_iden_load", &XArmDriver::_ft_sensor_iden_load);
 
         // FtCaliLoad
-        service_set_ft_sensor_load_offset_ = _create_service<xarm_msgs::srv::FtCaliLoad>("set_ft_sensor_load_offset", &XArmDriver::_set_ft_sensor_load_offset);
-        // OLD SERVICE
-        service_ft_sensor_cali_load_ = _create_service<xarm_msgs::srv::FtCaliLoad>("ft_sensor_cali_load", &XArmDriver::_set_ft_sensor_load_offset);
+        service_ft_sensor_cali_load_ = _create_service<xarm_msgs::srv::FtCaliLoad>("ft_sensor_cali_load", &XArmDriver::_ft_sensor_cali_load);
     
-        // FtForceParams
-        service_set_ft_force_ = _create_service<xarm_msgs::srv::FtForceParams>("set_ft_sensor_force_parameters", &XArmDriver::_set_ft_sensor_force_parameters);
         // FtForceConfig
-        // OLD SERVICE
         service_config_force_control_ = _create_service<xarm_msgs::srv::FtForceConfig>("config_force_control", &XArmDriver::_config_force_control);
+    
         // FtForcePid
-        // OLD SERVICE
         service_set_force_control_pid_ = _create_service<xarm_msgs::srv::FtForcePid>("set_force_control_pid", &XArmDriver::_set_force_control_pid);
-
-        // FtAdmittanceParams
-        service_set_ft_admittance_ = _create_service<xarm_msgs::srv::FtAdmittanceParams>("set_ft_sensor_admittance_parameters", &XArmDriver::_set_ft_sensor_admittance_parameters);
+    
         // FtImpedance
-        // OLD SERVICE
-        service_set_admittance_ = _create_service<xarm_msgs::srv::FtImpedance>("set_impedance", &XArmDriver::_set_admittance);
-        service_set_admittance_mbk_ = _create_service<xarm_msgs::srv::FtImpedance>("set_impedance_mbk", &XArmDriver::_set_admittance_mbk);
-        service_set_admittance_config_ = _create_service<xarm_msgs::srv::FtImpedance>("set_impedance_config", &XArmDriver::_set_admittance_config);
-        
-        // LinearMotorBackOrigin
-        service_set_linear_motor_back_origin_ = _create_service<xarm_msgs::srv::LinearMotorBackOrigin>("set_linear_motor_back_origin", &XArmDriver::_set_linear_motor_back_origin);
+        service_set_impedance_ = _create_service<xarm_msgs::srv::FtImpedance>("set_impedance", &XArmDriver::_set_impedance);
+        service_set_impedance_mbk_ = _create_service<xarm_msgs::srv::FtImpedance>("set_impedance_mbk", &XArmDriver::_set_impedance_mbk);
+        service_set_impedance_config_ = _create_service<xarm_msgs::srv::FtImpedance>("set_impedance_config", &XArmDriver::_set_impedance_config);
+    
         // LinearTrackBackOrigin
-        // OLD SERVICE
         service_set_linear_track_back_origin_ = _create_service<xarm_msgs::srv::LinearTrackBackOrigin>("set_linear_track_back_origin", &XArmDriver::_set_linear_track_back_origin);
     
-        //  LinearMotorSetPos
-        service_set_linear_motor_pos_ = _create_service<xarm_msgs::srv::LinearMotorSetPos>("set_linear_motor_pos", &XArmDriver::_set_linear_motor_pos);
         // LinearTrackSetPos
-        // OLD SERVICE
         service_set_linear_track_pos_ = _create_service<xarm_msgs::srv::LinearTrackSetPos>("set_linear_track_pos", &XArmDriver::_set_linear_track_pos);
     }
 
@@ -363,21 +326,21 @@ namespace xarm_api
         return true;
     }
 
-    bool XArmDriver::_set_ft_sensor_zero(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res)
+    bool XArmDriver::_ft_sensor_set_zero(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res)
     {
-        res->ret = arm->set_ft_sensor_zero();
+        res->ret = arm->ft_sensor_set_zero();
         return true;
     }
 
-    bool XArmDriver::_set_linear_motor_stop(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res)
+    bool XArmDriver::_set_linear_track_stop(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res)
     {
-        res->ret = arm->set_linear_motor_stop();
+        res->ret = arm->set_linear_track_stop();
         return true;
     }
 
-    bool XArmDriver::_clean_linear_motor_error(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res)
+    bool XArmDriver::_clean_linear_track_error(const std::shared_ptr<xarm_msgs::srv::Call::Request> req, std::shared_ptr<xarm_msgs::srv::Call::Response> res)
     {
-        res->ret = arm->clean_linear_motor_error();
+        res->ret = arm->clean_linear_track_error();
         return true;
     }
 
@@ -415,8 +378,9 @@ namespace xarm_api
 
     bool XArmDriver::_get_vacuum_gripper(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
     {
-        res->ret = arm->get_vacuum_gripper((int *)&res->data, vacuum_gripper_hardware_version_ != 0 ? vacuum_gripper_hardware_version_ : 1);
-        res->message = "hardware_version=" + std::to_string(vacuum_gripper_hardware_version_) + ", data=" + std::to_string(res->data);
+        // TODO: If vacuum is used here please, uncomment this and resolve later. 
+        // res->ret = arm->get_vacuum_gripper((int *)&res->data, vacuum_gripper_hardware_version_ != 0 ? vacuum_gripper_hardware_version_ : 1);
+        // res->message = "hardware_version=" + std::to_string(vacuum_gripper_hardware_version_) + ", data=" + std::to_string(res->data);
         return true;
     }
 
@@ -455,9 +419,9 @@ namespace xarm_api
         return true;
     }
 
-    bool XArmDriver::_get_ft_sensor_mode(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
+    bool XArmDriver::_ft_sensor_app_get(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
     {
-        res->ret = arm->get_ft_sensor_mode((int *)&res->data);
+        res->ret = arm->ft_sensor_app_get((int *)&res->data);
         res->message = "data=" + std::to_string(res->data);
         return true;
     }
@@ -476,44 +440,44 @@ namespace xarm_api
         return true;
     }
 
-    bool XArmDriver::_get_linear_motor_pos(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
+    bool XArmDriver::_get_linear_track_pos(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
     {
-        res->ret = arm->get_linear_motor_pos((int *)&res->data);
+        res->ret = arm->get_linear_track_pos((int *)&res->data);
         res->message = "data=" + std::to_string(res->data);
         return true;
     }
 
-    bool XArmDriver::_get_linear_motor_status(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
+    bool XArmDriver::_get_linear_track_status(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
     {
-        res->ret = arm->get_linear_motor_status((int *)&res->data);
+        res->ret = arm->get_linear_track_status((int *)&res->data);
         res->message = "data=" + std::to_string(res->data);
         return true;
     }
 
-    bool XArmDriver::_get_linear_motor_error(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
+    bool XArmDriver::_get_linear_track_error(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
     {
-        res->ret = arm->get_linear_motor_error((int *)&res->data);
+        res->ret = arm->get_linear_track_error((int *)&res->data);
         res->message = "data=" + std::to_string(res->data);
         return true;
     }
 
-    bool XArmDriver::_get_linear_motor_is_enabled(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
+    bool XArmDriver::_get_linear_track_is_enabled(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
     {
-        res->ret = arm->get_linear_motor_is_enabled((int *)&res->data);
+        res->ret = arm->get_linear_track_is_enabled((int *)&res->data);
         res->message = "data=" + std::to_string(res->data);
         return true;
     }
 
-    bool XArmDriver::_get_linear_motor_on_zero(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
+    bool XArmDriver::_get_linear_track_on_zero(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
     {
-        res->ret = arm->get_linear_motor_on_zero((int *)&res->data);
+        res->ret = arm->get_linear_track_on_zero((int *)&res->data);
         res->message = "data=" + std::to_string(res->data);
         return true;
     }
 
-    bool XArmDriver::_get_linear_motor_sci(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
+    bool XArmDriver::_get_linear_track_sci(const std::shared_ptr<xarm_msgs::srv::GetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16::Response> res)
     {
-        res->ret = arm->get_linear_motor_sci((int *)&res->data);
+        res->ret = arm->get_linear_track_sci((int *)&res->data);
         res->message = "data=" + std::to_string(res->data);
         return true;
     }
@@ -529,10 +493,10 @@ namespace xarm_api
         return true;
     }
 
-    bool XArmDriver::_get_linear_motor_sco(const std::shared_ptr<xarm_msgs::srv::GetInt16List::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16List::Response> res)
+    bool XArmDriver::_get_linear_track_sco(const std::shared_ptr<xarm_msgs::srv::GetInt16List::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt16List::Response> res)
     {
         int sco[2];
-        res->ret = arm->get_linear_motor_sco(sco);
+        res->ret = arm->get_linear_track_sco(sco);
         res->datas.resize(2);
         res->datas[0] = sco[0];
         res->datas[1]= sco[1];
@@ -646,30 +610,30 @@ namespace xarm_api
         return true; 
     }
 
-    bool XArmDriver::_set_ft_sensor_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
+    bool XArmDriver::_ft_sensor_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
     {
-        res->ret = arm->set_ft_sensor_enable(req->data);
+        res->ret = arm->ft_sensor_enable(req->data);
         res->message = "data=" + std::to_string(req->data);
         return true; 
     }
 
-    bool XArmDriver::_set_ft_sensor_mode(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
+    bool XArmDriver::_ft_sensor_app_set(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
     {
-        res->ret = arm->set_ft_sensor_mode(req->data);
+        res->ret = arm->ft_sensor_app_set(req->data);
         res->message = "data=" + std::to_string(req->data);
         return true; 
     }
 
-    bool XArmDriver::_set_linear_motor_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
+    bool XArmDriver::_set_linear_track_enable(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
     {
-        res->ret = arm->set_linear_motor_enable(req->data);
+        res->ret = arm->set_linear_track_enable(req->data);
         res->message = "data=" + std::to_string(req->data);
         return true; 
     }
 
-    bool XArmDriver::_set_linear_motor_speed(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
+    bool XArmDriver::_set_linear_track_speed(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
     {
-        res->ret = arm->set_linear_motor_speed(req->data);
+        res->ret = arm->set_linear_track_speed(req->data);
         res->message = "data=" + std::to_string(req->data);
         return true; 
     }
@@ -705,13 +669,6 @@ namespace xarm_api
     bool XArmDriver::_config_cgpio_reset_when_stop(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
     {
         res->ret = arm->config_cgpio_reset_when_stop(req->data);
-        res->message = "data=" + std::to_string(req->data);
-        return true;
-    }
-
-    bool XArmDriver::_set_rs485_use_503_port(const std::shared_ptr<xarm_msgs::srv::SetInt16::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16::Response> res)
-    {
-        res->ret = arm->set_rs485_use_503_port(req->data);
         res->message = "data=" + std::to_string(req->data);
         return true;
     }
@@ -761,19 +718,6 @@ namespace xarm_api
         }
         res->message = "datas=[ " + tmp + " ]";
         return true; 
-    }
-
-    bool XArmDriver::_set_external_device_monitor_params(const std::shared_ptr<xarm_msgs::srv::SetInt16List::Request> req, std::shared_ptr<xarm_msgs::srv::SetInt16List::Response> res)
-    {
-        if (req->datas.size() < 2) {
-            res->ret = PARAM_ERROR;
-            return true;
-        }
-        int dev_type = req->datas[0];
-        int frequency = req->datas[1];
-        res->ret = arm->set_external_device_monitor_params(dev_type, frequency);
-        res->message = "datas=[ " + std::to_string(dev_type) + ", " + std::to_string(frequency) + " ]";
-        return true;
     }
 
     bool XArmDriver::_get_tgpio_modbus_baudrate(const std::shared_ptr<xarm_msgs::srv::GetInt32::Request> req, std::shared_ptr<xarm_msgs::srv::GetInt32::Response> res)
@@ -1207,12 +1151,13 @@ namespace xarm_api
 
     bool XArmDriver::_set_vacuum_gripper(const std::shared_ptr<xarm_msgs::srv::VacuumGripperCtrl::Request> req, std::shared_ptr<xarm_msgs::srv::VacuumGripperCtrl::Response> res)
     {
-        if (req->hardware_version == 1 || req->hardware_version == 2) {
-            vacuum_gripper_hardware_version_ = req->hardware_version;
-        }
-        int hardware_version = req->hardware_version == 1 || req->hardware_version == 2 ? req->hardware_version : 1;
-        res->ret = arm->set_vacuum_gripper(req->on, req->wait, req->timeout, req->delay_sec, req->sync, hardware_version);
-        res->message = "hardware_version=" + std::to_string(vacuum_gripper_hardware_version_);
+        // TODO: If vacumm is used please uncomment this na dfix the version mismatch in vacuum hardware. 
+        // if (req->hardware_version == 1 || req->hardware_version == 2) {
+        //     vacuum_gripper_hardware_version_ = req->hardware_version;
+        // }
+        // int hardware_version = req->hardware_version == 1 || req->hardware_version == 2 ? req->hardware_version : 1;
+        // res->ret = arm->set_vacuum_gripper(req->on, req->wait, req->timeout, req->delay_sec, req->sync, hardware_version);
+        // res->message = "hardware_version=" + std::to_string(vacuum_gripper_hardware_version_);
         return true;
     }
 
@@ -1342,10 +1287,10 @@ namespace xarm_api
         return true; 
     }
 
-    bool XArmDriver::_iden_ft_sensor_load_offset(const std::shared_ptr<xarm_msgs::srv::IdenLoad::Request> req, std::shared_ptr<xarm_msgs::srv::IdenLoad::Response> res)
+    bool XArmDriver::_ft_sensor_iden_load(const std::shared_ptr<xarm_msgs::srv::IdenLoad::Request> req, std::shared_ptr<xarm_msgs::srv::IdenLoad::Response> res)
     {
         res->datas.resize(10);
-        res->ret = arm->iden_ft_sensor_load_offset(&res->datas[0]);
+        res->ret = arm->ft_sensor_iden_load(&res->datas[0]);
         std::string tmp = "";
         for (int i = 0; i < res->datas.size(); i++) {
             tmp += (i == 0 ? "" : ", ") + std::to_string(res->datas[i]);
@@ -1354,14 +1299,14 @@ namespace xarm_api
         return true; 
     }
 
-    bool XArmDriver::_set_ft_sensor_load_offset(const std::shared_ptr<xarm_msgs::srv::FtCaliLoad::Request> req, std::shared_ptr<xarm_msgs::srv::FtCaliLoad::Response> res)
+    bool XArmDriver::_ft_sensor_cali_load(const std::shared_ptr<xarm_msgs::srv::FtCaliLoad::Request> req, std::shared_ptr<xarm_msgs::srv::FtCaliLoad::Response> res)
     {
         if (req->datas.size() < 10) {
             res->ret = PARAM_ERROR;
             return true;
         }
 
-        res->ret = arm->set_ft_sensor_load_offset(&req->datas[0], req->association_setting_tcp_load, req->m, req->x, req->y, req->z);
+        res->ret = arm->ft_sensor_cali_load(&req->datas[0], req->association_setting_tcp_load, req->m, req->x, req->y, req->z);
         return true; 
     }
 
@@ -1375,7 +1320,7 @@ namespace xarm_api
         for (int i = 0; i < 6; i++) {
             axis[i] = req->c_axis[i];
         }
-        res->ret = arm->set_ft_sensor_force_parameters(req->coord, axis, &req->ref[0], &req->limits[0]);
+        res->ret = arm->config_force_control(req->coord, axis, &req->ref[0], &req->limits[0]);
         return true;
     }
     
@@ -1385,52 +1330,11 @@ namespace xarm_api
             res->ret = PARAM_ERROR;
             return true;
         }
-        res->ret = arm->set_ft_sensor_force_parameters(&req->kp[0], &req->ki[0], &req->kd[0], &req->xe_limit[0]);
+        res->ret = arm->set_force_control_pid(&req->kp[0], &req->ki[0], &req->kd[0], &req->xe_limit[0]);
         return true;
     }
 
-    bool XArmDriver::_set_ft_sensor_force_parameters(const std::shared_ptr<xarm_msgs::srv::FtForceParams::Request> req, std::shared_ptr<xarm_msgs::srv::FtForceParams::Response> res)
-    {
-        res->ret = PARAM_ERROR;
-        if (req->c_axis.size() >= 6 && req->ref.size() >= 6 && req->limits.size() >= 6) {
-            int axis[6] = { 0 };
-            for (int i = 0; i < 6; i++) {
-                axis[i] = req->c_axis[i];
-            }
-            res->ret = arm->set_ft_sensor_force_parameters(req->coord, axis, &req->ref[0], &req->limits[0]);
-        }
-        if (req->kp.size() >= 6 && req->ki.size() >= 6 && req->kd.size() >= 6 && req->xe_limit.size() >= 6) {
-            res->ret = arm->set_ft_sensor_force_parameters(&req->kp[0], &req->ki[0], &req->kd[0], &req->xe_limit[0]);
-        }
-        return true;
-    }
-
-    bool XArmDriver::_set_ft_sensor_admittance_parameters(const std::shared_ptr<xarm_msgs::srv::FtAdmittanceParams::Request> req, std::shared_ptr<xarm_msgs::srv::FtAdmittanceParams::Response> res)
-    {
-        if (req->c_axis.size() >= 6 && req->m.size() >= 6 && req->k.size() >= 6 && req->b.size() >= 6) {
-            int axis[6] = { 0 };
-            for (int i = 0; i < 6; i++) {
-                axis[i] = req->c_axis[i];
-            }
-            res->ret = arm->set_ft_sensor_admittance_parameters(req->coord, axis, &req->m[0], &req->k[0], &req->b[0]);
-        }
-        else if (req->c_axis.size() >= 6) {
-            int axis[6] = { 0 };
-            for (int i = 0; i < 6; i++) {
-                axis[i] = req->c_axis[i];
-            }
-            res->ret = arm->set_ft_sensor_admittance_parameters(req->coord, axis);
-        }
-        else if (req->m.size() >= 6 && req->k.size() >= 6 && req->b.size() >= 6) {
-            res->ret = arm->set_ft_sensor_admittance_parameters(&req->m[0], &req->k[0], &req->b[0]);
-        }
-        else {
-            res->ret = PARAM_ERROR;
-        }
-        return true;
-    }
-
-    bool XArmDriver::_set_admittance(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res)
+    bool XArmDriver::_set_impedance(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res)
     {
         if (req->c_axis.size() < 6 || req->m.size() < 6 || req->k.size() < 6 || req->b.size() < 6) {
             res->ret = PARAM_ERROR;
@@ -1440,21 +1344,21 @@ namespace xarm_api
         for (int i = 0; i < 6; i++) {
             axis[i] = req->c_axis[i];
         }
-        res->ret = arm->set_ft_sensor_admittance_parameters(req->coord, axis, &req->m[0], &req->k[0], &req->b[0]);
+        res->ret = arm->set_impedance(req->coord, axis, &req->m[0], &req->k[0], &req->b[0]);
         return true;
     }
 
-    bool XArmDriver::_set_admittance_mbk(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res)
+    bool XArmDriver::_set_impedance_mbk(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res)
     {
         if (req->m.size() < 6 || req->k.size() < 6 || req->b.size() < 6) {
             res->ret = PARAM_ERROR;
             return true;
         }
-        res->ret = arm->set_ft_sensor_admittance_parameters(&req->m[0], &req->k[0], &req->b[0]);
+        res->ret = arm->set_impedance_mbk(&req->m[0], &req->k[0], &req->b[0]);
         return true;
     }
 
-    bool XArmDriver::_set_admittance_config(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res)
+    bool XArmDriver::_set_impedance_config(const std::shared_ptr<xarm_msgs::srv::FtImpedance::Request> req, std::shared_ptr<xarm_msgs::srv::FtImpedance::Response> res)
     {
         if (req->c_axis.size() < 6) {
             res->ret = PARAM_ERROR;
@@ -1464,29 +1368,19 @@ namespace xarm_api
         for (int i = 0; i < 6; i++) {
             axis[i] = req->c_axis[i];
         }
-        res->ret = arm->set_ft_sensor_admittance_parameters(req->coord, axis);
+        res->ret = arm->set_impedance_config(req->coord, axis);
         return true;
     }
 
     bool XArmDriver::_set_linear_track_back_origin(const std::shared_ptr<xarm_msgs::srv::LinearTrackBackOrigin::Request> req, std::shared_ptr<xarm_msgs::srv::LinearTrackBackOrigin::Response> res)
     {
-        res->ret = arm->set_linear_motor_back_origin(req->wait, req->auto_enable);
-        return true; 
-    }
-    bool XArmDriver::_set_linear_motor_back_origin(const std::shared_ptr<xarm_msgs::srv::LinearMotorBackOrigin::Request> req, std::shared_ptr<xarm_msgs::srv::LinearMotorBackOrigin::Response> res)
-    {
-        res->ret = arm->set_linear_motor_back_origin(req->wait, req->auto_enable);
+        res->ret = arm->set_linear_track_back_origin(req->wait, req->auto_enable);
         return true; 
     }
 
     bool XArmDriver::_set_linear_track_pos(const std::shared_ptr<xarm_msgs::srv::LinearTrackSetPos::Request> req, std::shared_ptr<xarm_msgs::srv::LinearTrackSetPos::Response> res)
     {
-        res->ret = arm->set_linear_motor_pos(req->pos, req->speed, req->wait, req->timeout, req->auto_enable);
-        return true; 
-    }
-    bool XArmDriver::_set_linear_motor_pos(const std::shared_ptr<xarm_msgs::srv::LinearMotorSetPos::Request> req, std::shared_ptr<xarm_msgs::srv::LinearMotorSetPos::Response> res)
-    {
-        res->ret = arm->set_linear_motor_pos(req->pos, req->speed, req->wait, req->timeout, req->auto_enable);
+        res->ret = arm->set_linear_track_pos(req->pos, req->speed, req->wait, req->timeout, req->auto_enable);
         return true; 
     }
 }

--- a/xarm_controller/config/lite6_controllers.yaml
+++ b/xarm_controller/config/lite6_controllers.yaml
@@ -35,4 +35,3 @@ lite6_traj_controller:
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0
-    open_loop_control: true

--- a/xarm_controller/config/uf850_controllers.yaml
+++ b/xarm_controller/config/uf850_controllers.yaml
@@ -7,12 +7,29 @@ controller_manager:
 
     joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
-
-    servo_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
-    
+ 
     streaming_controller:
       type: position_controllers/JointGroupPositionController
+
+    # mecanum_drive_controller:
+    #   type: mecanum_drive_controller/MecanumDriveController
+
+joint_state_broadcaster:
+  ros__parameters:
+
+    joints: 
+      - joint1
+      - joint2
+      - joint3
+      - joint4
+      - joint5
+      - joint6
+
+    extra_joints:
+      - joint_wheel_front_left
+      - joint_wheel_front_right
+      - joint_wheel_back_left
+      - joint_wheel_back_right
 
 streaming_controller:
   ros__parameters:
@@ -27,47 +44,6 @@ streaming_controller:
       - position
     state_interfaces:
       - position
-
-servo_controller:
-  ros__parameters:
-    joints:
-      - joint1
-      - joint2
-      - joint3
-      - joint4
-      - joint5
-      - joint6
-    command_interfaces:
-      - position
-    state_interfaces:
-      - position
-      - velocity
-    command_joints:
-      - joint1
-      - joint2
-      - joint3
-      - joint4
-      - joint5
-      - joint6
-    state_publish_rate: 100.0
-    action_monitor_rate: 20.0
-    allow_partial_joints_goal: false
-    constraints:
-      stopped_velocity_tolerance: 0.0
-      goal_time: 0.0
-      joint1:
-        goal: 0.05
-      joint2:
-        goal: 0.05
-      joint3:
-        goal: 0.05
-      joint4:
-        goal: 0.05
-      joint5:
-        goal: 0.05
-      joint6:
-        goal: 0.05
-
 
 joint_trajectory_controller:
   ros__parameters:
@@ -96,3 +72,19 @@ joint_trajectory_controller:
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0
+
+# mecanum_drive_controller:
+#   ros__parameters:
+#     reference_timeout: 1.0 # max time between command messages before the vehicle should stop
+#     front_left_wheel_command_joint_name: "front_left_wheel_joint"
+#     front_right_wheel_command_joint_name: "front_right_wheel_joint"
+#     rear_right_wheel_command_joint_name: "rear_right_wheel_joint"
+#     rear_left_wheel_command_joint_name: "rear_left_wheel_joint"
+#     kinematics:
+#         base_frame_offset: { x: 0.0, y: 0.0, theta: 0.0 }
+#         wheels_radius: 0.3
+#         sum_of_robot_center_projection_on_X_Y_axis: 1.1
+#     base_frame_id: "base_link"
+#     odom_frame_id: "odom"
+#     enable_odom_tf: true
+    

--- a/xarm_controller/config/uf850_controllers.yaml
+++ b/xarm_controller/config/uf850_controllers.yaml
@@ -5,10 +5,71 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    uf850_traj_controller:
+    joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
-uf850_traj_controller:
+    servo_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+    
+    streaming_controller:
+      type: position_controllers/JointGroupPositionController
+
+streaming_controller:
+  ros__parameters:
+    joints:
+      - joint1
+      - joint2
+      - joint3
+      - joint4
+      - joint5
+      - joint6
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+
+servo_controller:
+  ros__parameters:
+    joints:
+      - joint1
+      - joint2
+      - joint3
+      - joint4
+      - joint5
+      - joint6
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    command_joints:
+      - joint1
+      - joint2
+      - joint3
+      - joint4
+      - joint5
+      - joint6
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.0
+      goal_time: 0.0
+      joint1:
+        goal: 0.05
+      joint2:
+        goal: 0.05
+      joint3:
+        goal: 0.05
+      joint4:
+        goal: 0.05
+      joint5:
+        goal: 0.05
+      joint6:
+        goal: 0.05
+
+
+joint_trajectory_controller:
   ros__parameters:
     command_interfaces:
       - position
@@ -35,4 +96,3 @@ uf850_traj_controller:
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0
-    open_loop_control: true

--- a/xarm_controller/config/xarm5_controllers.yaml
+++ b/xarm_controller/config/xarm5_controllers.yaml
@@ -33,4 +33,3 @@ xarm5_traj_controller:
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0
-    open_loop_control: true

--- a/xarm_controller/config/xarm6_controllers.yaml
+++ b/xarm_controller/config/xarm6_controllers.yaml
@@ -35,4 +35,3 @@ xarm6_traj_controller:
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0
-    open_loop_control: true

--- a/xarm_controller/config/xarm7_controllers.yaml
+++ b/xarm_controller/config/xarm7_controllers.yaml
@@ -5,14 +5,79 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    xarm7_traj_controller:
+    joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
+    
+    servo_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+    
+    streaming_controller:
+      type: position_controllers/JointGroupPositionController
 
-xarm7_traj_controller:
+streaming_controller:
+  ros__parameters:
+    joints:
+      - joint1
+      - joint2
+      - joint3
+      - joint4
+      - joint5
+      - joint6
+      - joint7
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+
+servo_controller:
+  ros__parameters:
+    joints:
+      - joint1
+      - joint2
+      - joint3
+      - joint4
+      - joint5
+      - joint6
+      - joint7
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    command_joints:
+      - joint1
+      - joint2
+      - joint3
+      - joint4
+      - joint5
+      - joint6
+      - joint7
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.0
+      goal_time: 0.0
+      joint1:
+        goal: 0.05
+      joint2:
+        goal: 0.05
+      joint3:
+        goal: 0.05
+      joint4:
+        goal: 0.05
+      joint5:
+        goal: 0.05
+      joint6:
+        goal: 0.05
+      joint7:
+        goal: 0.05
+
+joint_trajectory_controller:
   ros__parameters:
     command_interfaces:
       - position
-      - velocity
+      # - velocity
     state_interfaces:
       - position
       - velocity
@@ -36,4 +101,12 @@ xarm7_traj_controller:
     interface_name: position
     state_publish_rate: 25.0
     action_monitor_rate: 10.0
-    open_loop_control: true
+    
+    gains: 
+      joint1: { p: 100.0 , i : 0.0, d : 0.0, i_clamp: 0.0, normalise_error : False, angle_wraparound: False, ff_velocity_scale: 0.0}
+      joint2: { p: 200.0 , i : 0.0, d : 0.0, i_clamp: 0.0, normalise_error : False, angle_wraparound: False, ff_velocity_scale: 0.0}
+      joint3: { p: 100.0 , i : 0.0, d : 0.0, i_clamp: 0.0, normalise_error : False, angle_wraparound: False, ff_velocity_scale: 0.0}
+      joint4: { p: 200.0 , i : 0.0, d : 0.0, i_clamp: 0.0, normalise_error : False, angle_wraparound: False, ff_velocity_scale: 0.0}
+      joint5: { p: 100.0 , i : 0.0, d : 0.0, i_clamp: 0.0, normalise_error : False, angle_wraparound: False, ff_velocity_scale: 0.0}
+      joint6: { p: 100.0 , i : 0.0, d : 0.0, i_clamp: 0.0, normalise_error : False, angle_wraparound: False, ff_velocity_scale: 0.0}
+      joint7: { p: 50.0 , i : 0.0, d : 0.0, i_clamp: 0.0, normalise_error : False, angle_wraparound: False, ff_velocity_scale: 0.0}

--- a/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
+++ b/xarm_controller/include/xarm_controller/hardware/uf_robot_system_hardware.h
@@ -80,13 +80,13 @@ namespace uf_robot_hardware
         double read_max_time_;
         double read_total_time_;
         
-        // float prev_read_position_[7];
-		// float curr_read_position_[7];
-		// float curr_read_velocity_[7];
-		// float curr_read_effort_[7];
+        float prev_read_position_[7];
+		float curr_read_position_[7];
+		float curr_read_velocity_[7];
+		float curr_read_effort_[7];
         
-        // rclcpp::Time prev_read_time_;
-        // rclcpp::Time curr_read_time_;
+        rclcpp::Time prev_read_time_;
+        rclcpp::Time curr_read_time_;
         rclcpp::Time curr_write_time_;
         rclcpp::Time prev_write_time_;
 
@@ -109,6 +109,7 @@ namespace uf_robot_hardware
         bool _check_cmds_is_change(float *prev, float *cur, double threshold = 0.0001);
         bool _xarm_is_ready_read(void);
         bool _xarm_is_ready_write(void);
+        bool _firmware_version_is_ge(int major, int minor, int revision);
 
         bool _need_reset(void);
 

--- a/xarm_controller/launch/_dual_ros2_control.launch.py
+++ b/xarm_controller/launch/_dual_ros2_control.launch.py
@@ -123,7 +123,6 @@ def launch_setup(context, *args, **kwargs):
 
     robot_description = LaunchConfiguration('robot_description', default='')
     ros2_control_params = LaunchConfiguration('ros2_control_params', default='')
-    extra_robot_api_params_path = LaunchConfiguration('extra_robot_api_params_path', default='')
 
     if not ros2_control_params.perform(context):
         # ros2 control params
@@ -215,8 +214,7 @@ def launch_setup(context, *args, **kwargs):
     robot_params = generate_robot_api_params(
         os.path.join(get_package_share_directory('xarm_api'), 'config', 'xarm_params.yaml'),
         os.path.join(get_package_share_directory('xarm_api'), 'config', 'xarm_user_params.yaml'),
-        LaunchConfiguration('ros_namespace', default='').perform(context), node_name='ufactory_driver',
-        extra_robot_api_params_path=extra_robot_api_params_path.perform(context)
+        LaunchConfiguration('ros_namespace', default='').perform(context), node_name='ufactory_driver'
     )
 
     # ros2 control node

--- a/xarm_controller/launch/_ros2_control.launch.py
+++ b/xarm_controller/launch/_ros2_control.launch.py
@@ -61,7 +61,6 @@ def launch_setup(context, *args, **kwargs):
     
     robot_description = LaunchConfiguration('robot_description', default='')
     ros2_control_params = LaunchConfiguration('ros2_control_params', default='')
-    extra_robot_api_params_path = LaunchConfiguration('extra_robot_api_params_path', default='')
 
     if not ros2_control_params.perform(context):
         # ros2 control params
@@ -123,8 +122,7 @@ def launch_setup(context, *args, **kwargs):
     robot_params = generate_robot_api_params(
         os.path.join(get_package_share_directory('xarm_api'), 'config', 'xarm_params.yaml'),
         os.path.join(get_package_share_directory('xarm_api'), 'config', 'xarm_user_params.yaml'),
-        LaunchConfiguration('ros_namespace', default='').perform(context), node_name='ufactory_driver',
-        extra_robot_api_params_path=extra_robot_api_params_path.perform(context)
+        LaunchConfiguration('ros_namespace', default='').perform(context), node_name='ufactory_driver'
     )
 
     # ros2 control node

--- a/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
+++ b/xarm_controller/src/hardware/uf_robot_system_hardware.cpp
@@ -247,8 +247,6 @@ namespace uf_robot_hardware
 
     CallbackReturn UFRobotSystemHardware::on_activate(const rclcpp_lifecycle::State& previous_state)
     {
-        xarm_driver_.arm->clean_error();
-        xarm_driver_.arm->clean_warn();
         xarm_driver_.arm->motion_enable(true);
 		xarm_driver_.arm->set_mode(velocity_control_ ? XARM_MODE::VELO_JOINT : XARM_MODE::SERVO);
 		xarm_driver_.arm->set_state(XARM_STATE::START);
@@ -298,27 +296,54 @@ namespace uf_robot_hardware
         read_ready_ = _xarm_is_ready_read();
         rclcpp::Time start = node_->get_clock()->now();
 
-        read_code_ = xarm_driver_.update_joint_states(initialized_);
-        // double time_sec = joint_state_msg_->header.stamp.seconds() - start.seconds();
-        // read_total_time_ += time_sec;
-        // if (time_sec > read_max_time_) {
-        //     read_max_time_ = time_sec;
-        // }
+        bool use_new = _firmware_version_is_ge(1, 8, 103);
+        if (use_new)
+			read_code_ = xarm_driver_.arm->get_joint_states(curr_read_position_, curr_read_velocity_, curr_read_effort_);
+		else
+			read_code_ = xarm_driver_.arm->get_servo_angle(curr_read_position_);
+        
+        curr_read_time_ = node_->get_clock()->now();
+        read_ready_ = read_ready_ && _xarm_is_ready_read();
+        double time_sec = curr_read_time_.seconds() - start.seconds();
+        read_total_time_ += time_sec;
+        if (time_sec > read_max_time_) {
+            read_max_time_ = time_sec;
+        }
         // if (read_cnts_ % 6000 == 0) {
         //     RCLCPP_INFO(LOGGER, "[%s] [READ] cnt: %ld, max: %f, mean: %f, failed: %ld", robot_ip_.c_str(), read_cnts_, read_max_time_, read_total_time_ / read_cnts_, read_failed_cnts_);
         // }
         if (read_code_ == 0 && read_ready_) {
             for (int j = 0; j < info_.joints.size(); j++) {
-                position_states_[j] = joint_state_msg_->position[j];
-                velocity_states_[j] = joint_state_msg_->velocity[j];
-                // effort_states_[j] = joint_state_msg_->effort[j];
+                position_states_[j] = curr_read_position_[j];
+				if (use_new) {
+					velocity_states_[j] = curr_read_velocity_[j];
+					// effort_states_[j] = curr_read_effort_[j];
+				}
+				else {
+					velocity_states_[j] = !initialized_ ? 0.0 : (curr_read_position_[j] - prev_read_position_[j]) / (curr_read_time_.seconds() - prev_read_time_.seconds());
+					// effort_states_[j] = 0.0;
+				}
             }
+
+            // 20250318, update joint_states msg and publish
+            joint_state_msg_->header.stamp = curr_read_time_;
+            for(int i = 0; i < joint_state_msg_->position.size(); i++)
+            {
+                joint_state_msg_->position[i] = position_states_[i];
+                joint_state_msg_->velocity[i] = velocity_states_[i];
+                if (use_new)
+                    joint_state_msg_->effort[i] = (double)curr_read_effort_[i];
+            }
+            xarm_driver_.pub_joint_state(*joint_state_msg_);
+
             if (!initialized_) {
                 for (uint i = 0; i < position_states_.size(); i++) {
                     position_cmds_[i] = position_states_[i];
                     velocity_cmds_[i] = 0.0;
                 }
             }
+            memcpy(prev_read_position_, curr_read_position_, sizeof(float) * 7);
+            prev_read_time_ = curr_read_time_;
         }
         else {
             // initialized_ = read_ready_ && _xarm_is_ready_write();
@@ -500,6 +525,11 @@ namespace uf_robot_hardware
         last_not_ready = false;
         return true;
     }
+
+    bool UFRobotSystemHardware::_firmware_version_is_ge(int major, int minor, int revision)
+	{
+		return xarm_driver_.arm->version_number[0] > major || (xarm_driver_.arm->version_number[0] == major && xarm_driver_.arm->version_number[1] > minor) || (xarm_driver_.arm->version_number[0] == major && xarm_driver_.arm->version_number[1] == minor && xarm_driver_.arm->version_number[2] >= revision);
+	}
 
     bool UFRobotSystemHardware::_need_reset()
     {

--- a/xarm_description/urdf/camera/camera.gazebo.xacro
+++ b/xarm_description/urdf/camera/camera.gazebo.xacro
@@ -44,7 +44,7 @@
           <image>
             <width>640</width>
             <height>480</height>
-            <format>B8G8R8</format>
+            <foramt>B8G8R8</foramt>
           </image>
           <clip>
             <near>0.02</near>

--- a/xarm_description/urdf/camera/realsense.gazebo.xacro
+++ b/xarm_description/urdf/camera/realsense.gazebo.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="realsense_gazebo" params="prefix:=''">
-    <gazebo reference="${prefix}camera_depth_frame">
-      <sensor name="${prefix}cameradepth" type="depth">
-        <camera name="${prefix}camera">
+  <xacro:macro name="realsense_gazebo" params="prefix:='' ">
+    <!-- <gazebo reference="${prefix}camera_depth_frame">
+      <sensor name="cameradepth" type="depth">
+        <camera name="camera"> 
           <horizontal_fov>1.57</horizontal_fov>
           <image>
             <width>1280</width>
@@ -26,8 +26,8 @@
       </sensor>
     </gazebo>
     <gazebo reference="${prefix}camera_color_frame">
-      <sensor name="${prefix}cameracolor" type="camera">
-        <camera name="${prefix}camera">
+      <sensor name="cameracolor" type="camera">
+        <camera name="camera">
           <horizontal_fov>1.57</horizontal_fov>
           <image>
             <width>1280</width>
@@ -50,8 +50,8 @@
       </sensor>
     </gazebo>
     <gazebo reference="${prefix}camera_left_ir_frame">
-      <sensor name="${prefix}cameraired1" type="camera">
-        <camera name="${prefix}camera">
+      <sensor name="cameraired1" type="camera">
+        <camera name="camera">
           <horizontal_fov>1.57</horizontal_fov>
           <image>
             <width>1280</width>
@@ -74,8 +74,8 @@
       </sensor>
     </gazebo>
     <gazebo reference="${prefix}camera_right_ir_frame">
-      <sensor name="${prefix}cameraired2" type="camera">
-        <camera name="${prefix}camera">
+      <sensor name="cameraired2" type="camera">
+        <camera name="camera">
           <horizontal_fov>1.57</horizontal_fov>
           <image>
             <width>1280</width>
@@ -99,275 +99,93 @@
     </gazebo>
     <gazebo>
       <plugin name="realsense_gazebo_camera" filename="librealsense_gazebo_plugin.so">
-        <prefix>${prefix}camera</prefix>
+        <prefix>camera</prefix>
         <depthUpdateRate>30.0</depthUpdateRate>
         <colorUpdateRate>30.0</colorUpdateRate>
         <infraredUpdateRate>30.0</infraredUpdateRate>
-        <depthTopicName>${prefix}aligned_depth_to_color/image_raw</depthTopicName>
-        <depthCameraInfoTopicName>${prefix}depth/camera_info</depthCameraInfoTopicName>
-        <colorTopicName>${prefix}color/image_raw</colorTopicName>
-        <colorCameraInfoTopicName>${prefix}color/camera_info</colorCameraInfoTopicName>
-        <infrared1TopicName>${prefix}infra1/image_raw</infrared1TopicName>
-        <infrared1CameraInfoTopicName>${prefix}infra1/camera_info</infrared1CameraInfoTopicName>
-        <infrared2TopicName>${prefix}infra2/image_raw</infrared2TopicName>
-        <infrared2CameraInfoTopicName>${prefix}infra2/camera_info</infrared2CameraInfoTopicName>
-        <colorOpticalframeName>${prefix}camera_color_optical_frame</colorOpticalframeName>
-        <depthOpticalframeName>${prefix}camera_depth_optical_frame</depthOpticalframeName>
-        <infrared1OpticalframeName>${prefix}camera_left_ir_optical_frame</infrared1OpticalframeName>
-        <infrared2OpticalframeName>${prefix}camera_right_ir_optical_frame</infrared2OpticalframeName>
+        <depthTopicName>aligned_depth_to_color/image_raw</depthTopicName>
+        <depthCameraInfoTopicName>depth/camera_info</depthCameraInfoTopicName>
+        <colorTopicName>color/image_raw</colorTopicName>
+        <colorCameraInfoTopicName>color/camera_info</colorCameraInfoTopicName>
+        <infrared1TopicName>infra1/image_raw</infrared1TopicName>
+        <infrared1CameraInfoTopicName>infra1/camera_info</infrared1CameraInfoTopicName>
+        <infrared2TopicName>infra2/image_raw</infrared2TopicName>
+        <infrared2CameraInfoTopicName>infra2/camera_info</infrared2CameraInfoTopicName>
+        <colorOpticalframeName>camera_color_optical_frame</colorOpticalframeName>
+        <depthOpticalframeName>camera_depth_optical_frame</depthOpticalframeName>
+        <infrared1OpticalframeName>camera_left_ir_optical_frame</infrared1OpticalframeName>
+        <infrared2OpticalframeName>camera_right_ir_optical_frame</infrared2OpticalframeName>
         <rangeMinDepth>0.3</rangeMinDepth>
         <rangeMaxDepth>3.0</rangeMaxDepth>
         <pointCloud>true</pointCloud>
-        <pointCloudTopicName>${prefix}depth/color/points</pointCloudTopicName>
+        <pointCloudTopicName>depth/color/points</pointCloudTopicName>
         <pointCloudCutoff>0.3</pointCloudCutoff>
       </plugin>
-    </gazebo>
-  </xacro:macro>
+    </gazebo> -->
 
-  <xacro:macro name="realsense_ignition" params="prefix:=''">
-    <gazebo reference="${prefix}camera_depth_frame">
-      <sensor name="${prefix}cameradepth" type="rgbd_camera">
-        <camera name="${prefix}camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <depth_camera>
-            <clip>
-              <near>0.1</near>
-              <far>10</far>
-            </clip>
-          </depth_camera>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.100</stddev>
-          </noise>
-           <!-- <camera_info_topic>${prefix}camera/depth/camera_info</camera_info_topic> -->
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>0</visualize>
-        <topic>${prefix}camera/depth</topic>
-      </sensor>
-    </gazebo>
     <gazebo reference="${prefix}camera_color_frame">
-      <sensor name="${prefix}cameracolor" type="camera">
-        <!-- <ignition_frame_id>${prefix}camera_color_frame</ignition_frame_id>
-        <optical_frame_id>${prefix}camera_color_frame</optical_frame_id> -->
-        <camera name="${prefix}camera">
-          <horizontal_fov>1.57</horizontal_fov>
+      <sensor name="${prefix}_rgbd_sensor" type="rgbd_camera">
+        <camera>
+          <horizontal_fov>1.047</horizontal_fov>
           <image>
-            <width>1280</width>
-            <height>720</height>
+            <width>640</width>
+            <height>480</height>
             <format>RGB_INT8</format>
           </image>
           <clip>
             <near>0.1</near>
-            <far>100</far>
+            <far>5</far>
           </clip>
+          <distortion>
+            <k1>0.0</k1>
+            <k2>0.0</k2>
+            <k3>0.0</k3>
+            <p1>0.0</p1>
+            <p2>0.0</p2>
+            <center>0.5 0.5</center>
+          </distortion>
+          <lens>
+            <intrinsics>
+              <fx>554.25469</fx>
+              <fy>554.25469</fy>
+              <cx>320.5</cx>
+              <cy>240.5</cy>
+              <s>0</s>
+            </intrinsics>
+            <projection>
+              <p_fx>554.25469</p_fx>
+              <p_fy>554.25469</p_fy>
+              <p_cx>320.5</p_cx>
+              <p_cy>240.5</p_cy>
+              <tx>0</tx>
+              <ty>0</ty>
+            </projection>
+          </lens>
           <noise>
             <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.007</stddev>
+            <mean>0</mean>
+            <stddev>0.00</stddev>
           </noise>
-          <camera_info_topic>${prefix}camera/color/camera_info</camera_info_topic>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>1</visualize>
-        <topic>${prefix}camera/color/image_raw</topic>
-        <enable_metrics>true</enable_metrics>
-      </sensor>
-    </gazebo>
-    <gazebo reference="${prefix}camera_left_ir_frame">
-      <sensor name="${prefix}cameraired1" type="camera">
-        <camera name="${prefix}camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L_INT8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.05</stddev>
-          </noise>
-           <camera_info_topic>${prefix}camera/infra1/camera_info</camera_info_topic>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>0</visualize>
-        <topic>${prefix}camera/infra1/image_raw</topic>
-      </sensor>
-    </gazebo>
-    <gazebo reference="${prefix}camera_right_ir_frame">
-      <sensor name="${prefix}cameraired2" type="camera">
-        <camera name="${prefix}camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L_INT8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.05</stddev>
-          </noise>
-          <camera_info_topic>${prefix}camera/infra2/camera_info</camera_info_topic>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>0</visualize>
-        <topic>${prefix}camera/infra2/image_raw</topic>
-      </sensor>
-    </gazebo>
-    <gazebo>
-      <plugin
-        filename="libignition-gazebo-sensors-system.so"
-        name="ignition::gazebo::systems::Sensors">
-        <render_engine>ogre2</render_engine>
-      </plugin>
-    </gazebo>
-  </xacro:macro>
-
-  <xacro:macro name="realsense_gz" params="prefix:=''">
-    <gazebo reference="${prefix}camera_depth_frame">
-      <sensor name="${prefix}cameradepth" type="rgbd_camera">
-        <camera name="${prefix}camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
           <depth_camera>
             <clip>
-              <near>0.1</near>
-              <far>10</far>
+              <near>0.25</near>
+              <far>5</far>
             </clip>
           </depth_camera>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.100</stddev>
-          </noise>
-           <!-- <camera_info_topic>${prefix}camera/depth/camera_info</camera_info_topic> -->
+          <optical_frame_id>${prefix}camera_color_optical_frame</optical_frame_id>
         </camera>
+        <ignition_frame_id>${prefix}camera_color_frame</ignition_frame_id>
         <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>0</visualize>
-        <topic>${prefix}camera/depth</topic>
+        <update_rate>10.0</update_rate>
+        <visualize>false</visualize>
+        <topic>wrist_mounted_camera</topic>
+        <enable_metrics>false</enable_metrics>
+        
       </sensor>
+      
+
     </gazebo>
-    <gazebo reference="${prefix}camera_color_frame">
-      <sensor name="${prefix}cameracolor" type="camera">
-        <!-- <ignition_frame_id>${prefix}camera_color_frame</ignition_frame_id>
-        <optical_frame_id>${prefix}camera_color_frame</optical_frame_id> -->
-        <camera name="${prefix}camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>RGB_INT8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.007</stddev>
-          </noise>
-          <camera_info_topic>${prefix}camera/color/camera_info</camera_info_topic>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>1</visualize>
-        <topic>${prefix}camera/color/image_raw</topic>
-        <enable_metrics>true</enable_metrics>
-      </sensor>
-    </gazebo>
-    <gazebo reference="${prefix}camera_left_ir_frame">
-      <sensor name="${prefix}cameraired1" type="camera">
-        <camera name="${prefix}camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L_INT8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.05</stddev>
-          </noise>
-           <camera_info_topic>${prefix}camera/infra1/camera_info</camera_info_topic>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>0</visualize>
-        <topic>${prefix}camera/infra1/image_raw</topic>
-      </sensor>
-    </gazebo>
-    <gazebo reference="${prefix}camera_right_ir_frame">
-      <sensor name="${prefix}cameraired2" type="camera">
-        <camera name="${prefix}camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L_INT8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.05</stddev>
-          </noise>
-          <camera_info_topic>${prefix}camera/infra2/camera_info</camera_info_topic>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>0</visualize>
-        <topic>${prefix}camera/infra2/image_raw</topic>
-      </sensor>
-    </gazebo>
-    <gazebo>
-      <plugin
-        filename="libgz-sim-sensors-system.so"
-        name="gz::sim::systems::Sensors">
-        <render_engine>ogre2</render_engine>
-      </plugin>
-    </gazebo>
+    
   </xacro:macro>
 
 </robot>

--- a/xarm_description/urdf/common/common.gazebo.xacro
+++ b/xarm_description/urdf/common/common.gazebo.xacro
@@ -1,18 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="gz_ros2_control_plugin" params="ros2_control_params:=''">
-
-    <gazebo>
-      <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
-        <xacro:if value="${ros2_control_params != ''}">
-          <parameters>${ros2_control_params}</parameters>
-        </xacro:if>
-      </plugin>
-    </gazebo>
-
-  </xacro:macro>
-
   <xacro:macro name="ignition_ros2_control_plugin" params="prefix:='' ros2_control_params:=''">
 
     <gazebo>

--- a/xarm_description/urdf/gripper/xarm_gripper.gazebo.xacro
+++ b/xarm_description/urdf/gripper/xarm_gripper.gazebo.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- from mimic_joint_gazebo_tutorial by @mintar, refer: https://github.com/mintar/mimic_joint_gazebo_tutorial -->
-  <xacro:macro name="mimic_joint_plugin_gazebo" params="name_prefix following_joint mimic_joint has_pid:=false multiplier:=1.0 offset:=0 sensitiveness:=0.0 max_effort:=1.0 ros2_control_plugin:='gazebo_ros2_control/GazeboSystem' robot_namespace:=''">
+  <xacro:macro name="mimic_joint_plugin_gazebo" params="name_prefix following_joint mimic_joint has_pid:=false multiplier:=1.0 offset:=0 sensitiveness:=0.0 max_effort:=1.0 robot_namespace:=''">
     <!-- ros2 -->
     <xacro:if value="${is_ros2}"> 
       <xacro:property name="filename" value="libgazebo_mimic_joint_plugin.so" />
@@ -12,14 +12,8 @@
       <xacro:property name="filename" value="libroboticsgroup_gazebo_mimic_joint_plugin.so" />
       <!-- <xacro:property name="filename" value="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so" /> -->
     </xacro:unless>
-    <xacro:if value="${ros2_control_plugin == 'gazebo_ros2_control/GazeboSystem'}"> 
-      <xacro:property name="plugin_name" value="${name_prefix}mimic_joint_plugin" />
-    </xacro:if>
-    <xacro:unless value="${ros2_control_plugin == 'gazebo_ros2_control/GazeboSystem'}">
-      <xacro:property name="plugin_name" value="gz::sim::systems::GazeboMimicJointPlugin" />
-    </xacro:unless>
     <gazebo>
-      <plugin name="${plugin_name}" filename="${filename}">
+      <plugin name="${name_prefix}mimic_joint_plugin" filename="${filename}">
         <joint>${following_joint}</joint>
         <mimicJoint>${mimic_joint}</mimicJoint>
         <xacro:if value="${has_pid}">                     <!-- if set to true, PID parameters from "/gazebo_ros_control/pid_gains/${mimic_joint}" are loaded -->

--- a/xarm_description/urdf/gripper/xarm_gripper_macro.xacro
+++ b/xarm_description/urdf/gripper/xarm_gripper_macro.xacro
@@ -27,23 +27,23 @@
     <!-- mimic_joint_plugin has to be installed: -->
     <xacro:mimic_joint_plugin_gazebo name_prefix="${prefix}left_finger_joint"
       following_joint="${prefix}drive_joint" mimic_joint="${prefix}left_finger_joint"
-      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" ros2_control_plugin="${ros2_control_plugin}"/>
+      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" />
 
     <xacro:mimic_joint_plugin_gazebo name_prefix="${prefix}left_inner_knuckle_joint"
       following_joint="${prefix}drive_joint" mimic_joint="${prefix}left_inner_knuckle_joint"
-      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" ros2_control_plugin="${ros2_control_plugin}"/>
+      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" />
 
     <xacro:mimic_joint_plugin_gazebo name_prefix="${prefix}right_outer_knuckle_joint"
       following_joint="${prefix}drive_joint" mimic_joint="${prefix}right_outer_knuckle_joint"
-      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" ros2_control_plugin="${ros2_control_plugin}"/>
+      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" />
 
     <xacro:mimic_joint_plugin_gazebo name_prefix="${prefix}right_finger_joint"
       following_joint="${prefix}drive_joint" mimic_joint="${prefix}right_finger_joint"
-      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" ros2_control_plugin="${ros2_control_plugin}"/>
+      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" />
 
     <xacro:mimic_joint_plugin_gazebo name_prefix="${prefix}right_inner_knuckle_joint"
       following_joint="${prefix}drive_joint" mimic_joint="${prefix}right_inner_knuckle_joint"
-      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" ros2_control_plugin="${ros2_control_plugin}"/>
+      has_pid="${is_ros2}" multiplier="1.0" max_effort="10.0" />
 
   </xacro:macro>
 </robot>

--- a/xarm_description/urdf/uf850/uf850.ros2_control.xacro
+++ b/xarm_description/urdf/uf850/uf850.ros2_control.xacro
@@ -45,8 +45,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint2">
@@ -58,8 +62,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">0.3</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint3">
@@ -71,8 +79,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">-0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint4">
@@ -84,8 +96,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">-0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint5">
@@ -97,8 +113,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">-0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint6">
@@ -110,8 +130,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
     </ros2_control>

--- a/xarm_description/urdf/xarm7/xarm7.ros2_control.xacro
+++ b/xarm_description/urdf/xarm7/xarm7.ros2_control.xacro
@@ -38,8 +38,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint2">
@@ -51,8 +55,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">-1.186786</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>        
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint3">
@@ -64,8 +72,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint4">
@@ -77,8 +89,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">0.878955</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint5">
@@ -90,8 +106,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint6">
@@ -103,8 +123,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">1.449496</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
       <joint name="${prefix}joint7">
@@ -116,8 +140,12 @@
           <param name="min">-3.14</param>
           <param name="max">3.14</param>
         </command_interface>
-        <state_interface name="position"/>
-        <state_interface name="velocity"/>
+        <state_interface name="position">
+          <param name="initial_value">0.0</param>
+        </state_interface>
+        <state_interface name="velocity">
+          <param name="initial_value">0.0</param>
+        </state_interface>
         <!-- <state_interface name="effort"/> -->
       </joint>
     </ros2_control>

--- a/xarm_description/urdf/xarm_device.urdf.xacro
+++ b/xarm_description/urdf/xarm_device.urdf.xacro
@@ -22,6 +22,7 @@
   <xacro:arg name="add_realsense_d435i" default="false"/>
   <xacro:arg name="add_d435i_links" default="true"/>
   <xacro:arg name="use_gazebo_camera" default="false"/>
+  <xacro:arg name="add_depthai_camera" default="false"/>
 
   <xacro:arg name="add_other_geometry" default="false"/>
   <xacro:arg name="geometry_type" default="box"/>
@@ -56,6 +57,7 @@
     load_gazebo_plugin="true" ros2_control_params="$(arg ros2_control_params)"
     add_realsense_d435i="$(arg add_realsense_d435i)" 
     add_d435i_links="$(arg add_d435i_links)" 
+    add_depthai_camera="$(arg add_depthai_camera)"
     add_other_geometry="$(arg add_other_geometry)" 
     geometry_type="$(arg geometry_type)" geometry_mass="$(arg geometry_mass)"
     geometry_height="$(arg geometry_height)" geometry_radius="$(arg geometry_radius)"

--- a/xarm_description/urdf/xarm_device_macro.xacro
+++ b/xarm_description/urdf/xarm_device_macro.xacro
@@ -20,6 +20,7 @@
     load_gazebo_plugin:=false 
     add_realsense_d435i:=false
     add_d435i_links:=true
+    add_depthai_camera:=false
     use_gazebo_camera:=false
     add_other_geometry:=false 
     geometry_type:='box'
@@ -54,11 +55,11 @@
 
     <!-- Specify Mesh file path -->
     <xacro:property name="mesh_suffix" value="${mesh_suffix}" scope="parent"/>
-    <xacro:if value="${ros2_control_plugin == 'gazebo_ros2_control/GazeboSystem' or ros2_control_plugin == 'ign_ros2_control/IgnitionSystem' or ros2_control_plugin == 'gz_ros2_control/GazeboSimSystem'}">
+    <xacro:if value="${ros2_control_plugin == 'gazebo_ros2_control/GazeboSystem' or ros2_control_plugin == 'ign_ros2_control/IgnitionSystem'}">
       <!-- gazebo use -->
       <xacro:property name="mesh_path" value="file://$(find xarm_description)/meshes" scope="parent"/>
     </xacro:if>
-    <xacro:unless value="${ros2_control_plugin == 'gazebo_ros2_control/GazeboSystem' or ros2_control_plugin == 'ign_ros2_control/IgnitionSystem' or ros2_control_plugin == 'gz_ros2_control/GazeboSimSystem'}">
+    <xacro:unless value="${ros2_control_plugin == 'gazebo_ros2_control/GazeboSystem' or ros2_control_plugin == 'ign_ros2_control/IgnitionSystem'}">
       <xacro:property name="mesh_path" value="package://xarm_description/meshes" scope="parent"/>
     </xacro:unless> 
 
@@ -211,26 +212,32 @@
       </xacro:unless>
     </xacro:unless>
 
+
     <xacro:if value="${add_realsense_d435i}">
       <!-- (xarm) Load RealSense D435i URDF -->
       <xacro:include filename="$(find xarm_description)/urdf/camera/realsense_d435i.urdf.xacro" />
       <xacro:d435i_urdf prefix="${prefix}" add_d435i_links="${add_d435i_links}" />
       <xacro:if value="${add_d435i_links}">
         <xacro:include filename="$(find xarm_description)/urdf/camera/realsense.gazebo.xacro" />    
-        <xacro:if value="${ros2_control_plugin == 'gz_ros2_control/GazeboSimSystem'}">
-          <xacro:realsense_gz prefix="${prefix}" />
-        </xacro:if>
-        <xacro:if value="${ros2_control_plugin == 'ign_ros2_control/IgnitionSystem'}">
-          <xacro:realsense_ignition prefix="${prefix}" />
-        </xacro:if>
-        <xacro:if value="${ros2_control_plugin == 'gazebo_ros2_control/GazeboSystem'}">
-          <xacro:realsense_gazebo prefix="${prefix}" />
-        </xacro:if>
+        <xacro:realsense_gazebo prefix="${prefix}" />
       </xacro:if>
     </xacro:if>
     <xacro:unless value="${add_realsense_d435i}">
-      <link name="${prefix}link_eef"/>
+
+      <!-- Add depthai camera  -->
+      <!-- TODO: check how to start depthai camera simulation. -->
+      <!-- probably use use_gazebo_camera or add an arg to start simulation -->
+      <xacro:if value="${add_depthai_camera}">
+        <xacro:include filename="$(find abluo_description)/description/camera.urdf.xacro" />
+        <xacro:depthai_camera prefix="${prefix}"  />
+      </xacro:if>
+      <xacro:unless value="${add_depthai_camera}">
+        <link name="${prefix}link_eef"/>
+      </xacro:unless>
+      
     </xacro:unless>
+
+
     <joint name="${prefix}joint_eef" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0" />
       <parent link="${prefix}link${dof}" />
@@ -299,15 +306,12 @@
         <xacro:if value="${ros2_control_params != ''}">
           <xacro:property name="new_ros2_control_params" value="${ros2_control_params}"/>
         </xacro:if>
-        <xacro:if value="${ros2_control_plugin == 'gz_ros2_control/GazeboSimSystem'}">
-          <xacro:gz_ros2_control_plugin ros2_control_params="${new_ros2_control_params}"/>
-        </xacro:if>
         <xacro:if value="${ros2_control_plugin == 'ign_ros2_control/IgnitionSystem'}">
           <xacro:ignition_ros2_control_plugin prefix="${prefix}" ros2_control_params="${new_ros2_control_params}"/>
         </xacro:if>
-        <xacro:if value="${ros2_control_plugin == 'gazebo_ros2_control/GazeboSystem'}">
+        <xacro:unless value="${ros2_control_plugin == 'ign_ros2_control/IgnitionSystem'}">
           <xacro:gazebo_ros2_control_plugin ros2_control_params="${new_ros2_control_params}"/>
-        </xacro:if>
+        </xacro:unless>
       </xacro:if>
       <xacro:unless value="${is_ros2}">
         <xacro:gazebo_ros1_control_plugin namespace="${hw_ns}"/>

--- a/xarm_description/urdf/xarm_device_macro.xacro
+++ b/xarm_description/urdf/xarm_device_macro.xacro
@@ -228,7 +228,7 @@
       <!-- TODO: check how to start depthai camera simulation. -->
       <!-- probably use use_gazebo_camera or add an arg to start simulation -->
       <xacro:if value="${add_depthai_camera}">
-        <xacro:include filename="$(find abluo_description)/description/camera.urdf.xacro" />
+        <xacro:include filename="$(find hivebotics_description)/description/camera.urdf.xacro" />
         <xacro:depthai_camera prefix="${prefix}"  />
       </xacro:if>
       <xacro:unless value="${add_depthai_camera}">

--- a/xarm_gazebo/launch/_dual_robot_beside_table_gazebo.launch.py
+++ b/xarm_gazebo/launch/_dual_robot_beside_table_gazebo.launch.py
@@ -44,7 +44,7 @@ def launch_setup(context, *args, **kwargs):
     limited = LaunchConfiguration('limited', default=False)
     effort_control = LaunchConfiguration('effort_control', default=False)
     velocity_control = LaunchConfiguration('velocity_control', default=False)
-    ros2_control_plugin = LaunchConfiguration('ros2_control_plugin', default='')
+    ros2_control_plugin = LaunchConfiguration('ros2_control_plugin', default='gazebo_ros2_control/GazeboSystem')
     
     add_realsense_d435i = LaunchConfiguration('add_realsense_d435i', default=False)
     add_realsense_d435i_1 = LaunchConfiguration('add_realsense_d435i_1', default=add_realsense_d435i)
@@ -120,11 +120,6 @@ def launch_setup(context, *args, **kwargs):
 
     ros_namespace = LaunchConfiguration('ros_namespace', default='').perform(context)
     moveit_config_dump = LaunchConfiguration('moveit_config_dump', default='')
-
-    gz_type = LaunchConfiguration('gz_type', default='gazebo').perform(context)
-    gz_type = 'ignition' if gz_type == 'ign' else gz_type
-    if ros2_control_plugin.perform(context) == '':
-        ros2_control_plugin = 'gz_ros2_control/GazeboSimSystem' if gz_type == 'gz' else 'ign_ros2_control/IgnitionSystem' if gz_type == 'ignition' else 'gazebo_ros2_control/GazeboSystem'
 
     moveit_config_dump = moveit_config_dump.perform(context)
     moveit_config_dict = yaml.load(moveit_config_dump, Loader=yaml.FullLoader) if moveit_config_dump else {}
@@ -224,112 +219,34 @@ def launch_setup(context, *args, **kwargs):
         ]
     )
 
-    if gz_type == 'gz':
-        gazebo_world = PathJoinSubstitution([FindPackageShare('xarm_gazebo'), 'worlds', 'table_gz.world'])
-        # ros_gz_sim/launch/gz_sim.launch.py
-        gazebo_launch = IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('ros_gz_sim'), 'launch', 'gz_sim.launch.py'])),
-            launch_arguments={
-                'gz_args': ' -r -v 3 {}'.format(gazebo_world.perform(context)),
-            }.items(),
-        )
-        # gazebo spawn entity node
-        gazebo_spawn_entity_node = Node(
-            package="ros_gz_sim",
-            executable="create",
-            output='screen',
-            arguments=[
-                '-topic', 'robot_description',
-                '-name', 'DUAL_UF_ROBOT',
-                '-x', '0.5',
-                '-y', '-0.54' if robot_type.perform(context) == 'uf850' else '-0.5',
-                '-z', '1.021',
-                '-Y', '1.571',
-            ],
-            parameters=[{'use_sim_time': True}],
-        )
-        # Gz - ROS Bridge
-        gz_bridge = Node(
-            package='ros_gz_bridge',
-            executable='parameter_bridge',
-            arguments=[
-                # Clock (IGN -> ROS2)
-                '/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock',
-                # Joint states (IGN -> ROS2)
-                # '/world/empty/model/DUAL_UF_ROBOT/joint_state@sensor_msgs/msg/JointState[gz.msgs.Model',
-            ],
-            remappings=[
-                # ('/world/empty/model/DUAL_UF_ROBOT/joint_state', 'joint_states'),
-            ],
-            output='screen'
-        )
-    elif gz_type == 'ignition':
-        gazebo_world = PathJoinSubstitution([FindPackageShare('xarm_gazebo'), 'worlds', 'table_gz.world'])
-        # ros_ign_gazebo/launch/ign_gazebo.launch.py
-        gazebo_launch = IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('ros_ign_gazebo'), 'launch', 'ign_gazebo.launch.py'])),
-            launch_arguments={
-                'ign_args': ' -r -v 3 {}'.format(gazebo_world.perform(context)),
-            }.items(),
-        )
-        # gazebo spawn entity node
-        gazebo_spawn_entity_node = Node(
-            package="ros_ign_gazebo",
-            executable="create",
-            output='screen',
-            arguments=[
-                '-topic', 'robot_description',
-                # '-name', '{}'.format(xarm_type),
-                '-name', 'DUAL_UF_ROBOT',
-                '-x', '0.5',
-                '-y', '-0.54' if robot_type.perform(context) == 'uf850' else '-0.5',
-                '-z', '1.021',
-                '-Y', '1.571',
-                # '-allow_renaming', 'true'
-            ],
-            parameters=[{'use_sim_time': True}],
-        )
-        # IGN - ROS Bridge
-        gz_bridge = Node(
-            package='ros_ign_bridge',
-            executable='parameter_bridge',
-            arguments=[
-                # Clock (IGN -> ROS2)
-                '/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock',
-                # # Joint states (IGN -> ROS2)
-                # '/xarm/joint_states@sensor_msgs/msg/JointState[ignition.msgs.Model',
-            ],
-            # remappings=[
-            #     ('/xarm/joint_states', 'joint_states'),
-            # ],
-            output='screen'
-        )
-    else:
-        gazebo_world = PathJoinSubstitution([FindPackageShare('xarm_gazebo'), 'worlds', 'table.world'])
-        # gazebo_ros/launch/gazebo.launch.py
-        gazebo_launch = IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('gazebo_ros'), 'launch', 'gazebo.launch.py'])),
-            launch_arguments={
-                'world': gazebo_world,
-                'server_required': 'true',
-                'gui_required': 'true',
-            }.items(),
-        )
-        # gazebo spawn entity node
-        gazebo_spawn_entity_node = Node(
-            package="gazebo_ros",
-            executable="spawn_entity.py",
-            output='screen',
-            arguments=[
-                '-topic', 'robot_description',
-                '-entity', 'DUAL_UF_ROBOT',
-                '-x', '0.5',
-                '-y', '-0.54' if robot_type.perform(context) == 'uf850' else '-0.5',
-                '-z', '1.021',
-                '-Y', '1.571',
-            ],
-            parameters=[{'use_sim_time': True}],
-        )
+    # gazebo launch
+    # gazebo_ros/launch/gazebo.launch.py
+    xarm_gazebo_world = PathJoinSubstitution([FindPackageShare('xarm_gazebo'), 'worlds', 'table.world'])
+    gazebo_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('gazebo_ros'), 'launch', 'gazebo.launch.py'])),
+        launch_arguments={
+            'world': xarm_gazebo_world,
+            'server_required': 'true',
+            'gui_required': 'true',
+            # 'pause': 'true'
+        }.items(),
+    )
+
+    # gazebo spawn entity node
+    gazebo_spawn_entity_node = Node(
+        package="gazebo_ros",
+        executable="spawn_entity.py",
+        output='screen',
+        arguments=[
+            '-topic', 'robot_description',
+            '-entity', 'DUAL_UF_ROBOT',
+            '-x', '0.5',
+            '-y', '-0.54' if robot_type.perform(context) == 'uf850' else '-0.5',
+            '-z', '1.021',
+            '-Y', '1.571',
+        ],
+        parameters=[{'use_sim_time': True}],
+    )
 
     # rviz with moveit configuration
     rviz_config_file = PathJoinSubstitution([FindPackageShare(moveit_config_package_name), 'rviz', 'dual_planner.rviz' if no_gui_ctrl.perform(context) == 'true' else 'dual_moveit.rviz'])
@@ -387,46 +304,62 @@ def launch_setup(context, *args, **kwargs):
                 parameters=[{'use_sim_time': True}],
             ))
     
-    nodes = [
-        RegisterEventHandler(
-            event_handler=OnProcessStart(
-                target_action=robot_state_publisher_node,
-                on_start=gazebo_launch,
-            )
-        ),
-        RegisterEventHandler(
-            event_handler=OnProcessStart(
-                target_action=robot_state_publisher_node,
-                on_start=gazebo_spawn_entity_node,
-            )
-        ),
-        RegisterEventHandler(
-            condition=IfCondition(show_rviz),
-            event_handler=OnProcessExit(
-                target_action=gazebo_spawn_entity_node,
-                on_exit=rviz2_node,
-            )
-        ),
-        robot_state_publisher_node
-    ]
-
-    if gz_type == 'gz' or gz_type == 'ignition':
-        nodes.append(RegisterEventHandler(
-            event_handler=OnProcessStart(
-                target_action=robot_state_publisher_node,
-                on_start=gz_bridge,
-            )
-        ))
-
     if len(controller_nodes) > 0:
-        nodes.append(RegisterEventHandler(
-            event_handler=OnProcessExit(
-                target_action=gazebo_spawn_entity_node,
-                on_exit=controller_nodes,
-            )
-        ))
-
-    return nodes
+        return [
+            RegisterEventHandler(
+                event_handler=OnProcessStart(
+                    target_action=robot_state_publisher_node,
+                    on_start=gazebo_launch,
+                )
+            ),
+            RegisterEventHandler(
+                event_handler=OnProcessStart(
+                    target_action=robot_state_publisher_node,
+                    on_start=gazebo_spawn_entity_node,
+                )
+            ),
+            RegisterEventHandler(
+                condition=IfCondition(show_rviz),
+                event_handler=OnProcessExit(
+                    target_action=gazebo_spawn_entity_node,
+                    on_exit=rviz2_node,
+                )
+            ),
+            RegisterEventHandler(
+                event_handler=OnProcessExit(
+                    target_action=gazebo_spawn_entity_node,
+                    on_exit=controller_nodes,
+                )
+            ),
+            robot_state_publisher_node,
+            # gazebo_launch,
+            # gazebo_spawn_entity_node,
+        ]
+    else:
+        return [
+            RegisterEventHandler(
+                event_handler=OnProcessStart(
+                    target_action=robot_state_publisher_node,
+                    on_start=gazebo_launch,
+                )
+            ),
+            RegisterEventHandler(
+                event_handler=OnProcessStart(
+                    target_action=robot_state_publisher_node,
+                    on_start=gazebo_spawn_entity_node,
+                )
+            ),
+            RegisterEventHandler(
+                condition=IfCondition(show_rviz),
+                event_handler=OnProcessExit(
+                    target_action=gazebo_spawn_entity_node,
+                    on_exit=rviz2_node,
+                )
+            ),
+            robot_state_publisher_node,
+            # gazebo_launch,
+            # gazebo_spawn_entity_node,
+        ]
 
 
 def generate_launch_description():

--- a/xarm_gazebo/launch/_robot_beside_table_ignition.launch.py
+++ b/xarm_gazebo/launch/_robot_beside_table_ignition.launch.py
@@ -10,7 +10,6 @@ import os
 import yaml
 from pathlib import Path
 from ament_index_python import get_package_share_directory
-from launch.launch_description_sources import load_python_launch_file_as_module
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument, RegisterEventHandler
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -34,7 +33,7 @@ def launch_setup(context, *args, **kwargs):
     add_bio_gripper = LaunchConfiguration('add_bio_gripper', default=False)
     dof = LaunchConfiguration('dof', default=7)
     robot_type = LaunchConfiguration('robot_type', default='xarm')
-    ros2_control_plugin = LaunchConfiguration('ros2_control_plugin', default='gazebo_ros2_control/GazeboSystem')
+    ros2_control_plugin = LaunchConfiguration('ros2_control_plugin', default='ign_ros2_control/IgnitionSystem')
     
     add_realsense_d435i = LaunchConfiguration('add_realsense_d435i', default=False)
     add_d435i_links = LaunchConfiguration('add_d435i_links', default=True)
@@ -138,32 +137,47 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # gazebo launch
-    # gazebo_ros/launch/gazebo.launch.py
+    # ros_ign_gazebo/launch/ign_gazebo.launch.py
     xarm_gazebo_world = PathJoinSubstitution([FindPackageShare('xarm_gazebo'), 'worlds', 'table.world'])
     gazebo_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('gazebo_ros'), 'launch', 'gazebo.launch.py'])),
+        PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('ros_ign_gazebo'), 'launch', 'ign_gazebo.launch.py'])),
         launch_arguments={
-            'world': xarm_gazebo_world,
-            'server_required': 'true',
-            'gui_required': 'true',
+            'ign_args': ' -r -v 3 {}'.format(xarm_gazebo_world.perform(context)),
+            # 'gz_args': ' -r -v 3 {}'.format(xarm_gazebo_world.perform(context)),
         }.items(),
     )
 
     # gazebo spawn entity node
     gazebo_spawn_entity_node = Node(
-        package="gazebo_ros",
-        executable="spawn_entity.py",
+        package="ros_ign_gazebo",
+        executable="create",
         output='screen',
         arguments=[
             '-topic', 'robot_description',
-            # '-entity', '{}'.format(xarm_type),
-            '-entity', 'UF_ROBOT',
+            # '-name', '{}'.format(xarm_type),
+            '-name', 'UF_ROBOT',
             '-x', '-0.2',
             '-y', '-0.54' if robot_type.perform(context) == 'uf850' else '-0.5',
             '-z', '1.021',
             '-Y', '1.571',
+            # '-allow_renaming', 'true'
         ],
         parameters=[{'use_sim_time': True}],
+    )
+
+    ign_bridge = Node(
+        package='ros_ign_bridge',
+        executable='parameter_bridge',
+        arguments=[
+            # Clock (IGN -> ROS2)
+            '/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock',
+            # # Joint states (IGN -> ROS2)
+            # '/xarm/joint_states@sensor_msgs/msg/JointState[ignition.msgs.Model',
+        ],
+        # remappings=[
+        #     ('/xarm/joint_states', 'joint_states'),
+        # ],
+        output='screen'
     )
 
     # rviz with moveit configuration
@@ -230,6 +244,12 @@ def launch_setup(context, *args, **kwargs):
                 )
             ),
             RegisterEventHandler(
+                event_handler=OnProcessStart(
+                    target_action=robot_state_publisher_node,
+                    on_start=ign_bridge,
+                )
+            ),
+            RegisterEventHandler(
                 condition=IfCondition(show_rviz),
                 event_handler=OnProcessExit(
                     target_action=gazebo_spawn_entity_node,
@@ -244,6 +264,7 @@ def launch_setup(context, *args, **kwargs):
             ),
             robot_state_publisher_node,
             # gazebo_launch,
+            # ign_bridge,
             # gazebo_spawn_entity_node,
         ]
     else:
@@ -261,6 +282,12 @@ def launch_setup(context, *args, **kwargs):
                 )
             ),
             RegisterEventHandler(
+                event_handler=OnProcessStart(
+                    target_action=robot_state_publisher_node,
+                    on_start=ign_bridge,
+                )
+            ),
+            RegisterEventHandler(
                 condition=IfCondition(show_rviz),
                 event_handler=OnProcessExit(
                     target_action=gazebo_spawn_entity_node,
@@ -269,6 +296,7 @@ def launch_setup(context, *args, **kwargs):
             ),
             robot_state_publisher_node,
             # gazebo_launch,
+            # ign_bridge,
             # gazebo_spawn_entity_node,
         ]
 

--- a/xarm_moveit_config/launch/_dual_robot_moveit_gazebo.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_gazebo.launch.py
@@ -98,10 +98,7 @@ def launch_setup(context, *args, **kwargs):
     no_gui_ctrl = LaunchConfiguration('no_gui_ctrl', default=False)
     ros_namespace = LaunchConfiguration('ros_namespace', default='').perform(context)
 
-    gz_type = LaunchConfiguration('gz_type', default='gazebo').perform(context)
-    gz_type = 'ignition' if gz_type == 'ign' else gz_type
-
-    ros2_control_plugin = 'gz_ros2_control/GazeboSimSystem' if gz_type == 'gz' else 'ign_ros2_control/IgnitionSystem' if gz_type == 'ignition' else 'gazebo_ros2_control/GazeboSystem'
+    ros2_control_plugin = 'gazebo_ros2_control/GazeboSystem'
     controllers_name = 'fake_controllers'
 
     ros2_control_params = generate_dual_ros2_control_params_temp_file(
@@ -209,7 +206,6 @@ def launch_setup(context, *args, **kwargs):
             'load_controller': 'true',
             'show_rviz': 'true',
             'no_gui_ctrl': no_gui_ctrl,
-            'gz_type': gz_type,
         }.items(),
     )
 

--- a/xarm_moveit_config/launch/_dual_robot_moveit_realmove.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_realmove.launch.py
@@ -108,7 +108,6 @@ def launch_setup(context, *args, **kwargs):
 
     no_gui_ctrl = LaunchConfiguration('no_gui_ctrl', default=False)
     ros_namespace = LaunchConfiguration('ros_namespace', default='').perform(context)
-    extra_robot_api_params_path = LaunchConfiguration('extra_robot_api_params_path', default='')
 
     ros2_control_plugin = 'uf_robot_hardware/UFRobotSystemHardware'
     controllers_name = 'controllers'
@@ -246,7 +245,6 @@ def launch_setup(context, *args, **kwargs):
         launch_arguments={
             'robot_description': yaml.dump(moveit_config.robot_description),
             'ros2_control_params': ros2_control_params,
-            'extra_robot_api_params_path': extra_robot_api_params_path,
         }.items(),
     )
 

--- a/xarm_moveit_config/launch/_robot_moveit_common2.launch.py
+++ b/xarm_moveit_config/launch/_robot_moveit_common2.launch.py
@@ -29,7 +29,6 @@ def launch_setup(context, *args, **kwargs):
     show_rviz = LaunchConfiguration('show_rviz', default=True)
     use_sim_time = LaunchConfiguration('use_sim_time', default=False)
     moveit_config_dump = LaunchConfiguration('moveit_config_dump')
-    rviz_config = LaunchConfiguration('rviz_config', default='')
     
     moveit_config_dump = moveit_config_dump.perform(context)
     moveit_config_dict = yaml.load(moveit_config_dump, Loader=yaml.FullLoader)
@@ -47,10 +46,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # rviz with moveit configuration
-    if not rviz_config.perform(context):
-        rviz_config_file = PathJoinSubstitution([FindPackageShare(moveit_config_package_name), 'rviz', 'planner.rviz' if no_gui_ctrl.perform(context) == 'true' else 'moveit.rviz'])
-    else:
-        rviz_config_file = rviz_config
+    rviz_config_file = PathJoinSubstitution([FindPackageShare(moveit_config_package_name), 'rviz', 'planner.rviz' if no_gui_ctrl.perform(context) == 'true' else 'moveit.rviz'])
     rviz2_node = Node(
         package='rviz2',
         executable='rviz2',

--- a/xarm_moveit_config/launch/_robot_moveit_ignition.launch.py
+++ b/xarm_moveit_config/launch/_robot_moveit_ignition.launch.py
@@ -55,7 +55,7 @@ def launch_setup(context, *args, **kwargs):
     no_gui_ctrl = LaunchConfiguration('no_gui_ctrl', default=False)
     ros_namespace = LaunchConfiguration('ros_namespace', default='').perform(context)
 
-    ros2_control_plugin = 'gazebo_ros2_control/GazeboSystem'
+    ros2_control_plugin = 'ign_ros2_control/IgnitionSystem'
     controllers_name = 'fake_controllers'
 
     ros2_control_params = generate_ros2_control_params_temp_file(
@@ -126,9 +126,9 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # robot gazebo launch
-    # xarm_gazebo/launch/_robot_beside_table_gazebo.launch.py
+    # xarm_gazebo/launch/_robot_beside_table_ignition.launch.py
     robot_gazebo_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('xarm_gazebo'), 'launch', '_robot_beside_table_gazebo.launch.py'])),
+        PythonLaunchDescriptionSource(PathJoinSubstitution([FindPackageShare('xarm_gazebo'), 'launch', '_robot_beside_table_ignition.launch.py'])),
         launch_arguments={
             'dof': dof,
             'robot_type': robot_type,

--- a/xarm_moveit_servo/config/xarm_moveit_servo_config.yaml
+++ b/xarm_moveit_servo/config/xarm_moveit_servo_config.yaml
@@ -7,13 +7,13 @@ use_gazebo: false # Whether the robot is started in a Gazebo simulation environm
 command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
   # Scale parameters are only used if command_in_type=="unitless"
-  linear:  0.1  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
-  rotational:  0.1 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
+  linear:  0.4  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.8 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
   # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
-  joint: 0.01
+  joint: 0.5
 
 ## Properties of outgoing commands
-publish_period: 0.067  # 1/Nominal publish rate [seconds]
+publish_period: 0.034  # 1/Nominal publish rate [seconds]
 low_latency_mode: false  # Set this to true to publish as soon as an incoming Twist command is received (publish_period is ignored)
 
 # What type of topic does your robot driver expect?

--- a/xarm_msgs/CMakeLists.txt
+++ b/xarm_msgs/CMakeLists.txt
@@ -84,22 +84,16 @@ set(srv_files
 
   ${srv_dir}/IdenLoad.srv
   ${srv_dir}/FtCaliLoad.srv
-  ${srv_dir}/FtForceParams.srv
-  ${srv_dir}/FtAdmittanceParams.srv
-  ${srv_dir}/LinearMotorBackOrigin.srv
-  ${srv_dir}/LinearMotorSetPos.srv
-
-  ${srv_dir}/PlanExec.srv
-  ${srv_dir}/PlanJoint.srv
-  ${srv_dir}/PlanPose.srv
-  ${srv_dir}/PlanSingleStraight.srv
-
-  # OLD
   ${srv_dir}/FtForceConfig.srv
   ${srv_dir}/FtForcePid.srv
   ${srv_dir}/FtImpedance.srv
   ${srv_dir}/LinearTrackBackOrigin.srv
   ${srv_dir}/LinearTrackSetPos.srv
+
+  ${srv_dir}/PlanExec.srv
+  ${srv_dir}/PlanJoint.srv
+  ${srv_dir}/PlanPose.srv
+  ${srv_dir}/PlanSingleStraight.srv
 )
 
 # set(active_files

--- a/xarm_msgs/ReadMe.md
+++ b/xarm_msgs/ReadMe.md
@@ -10,7 +10,7 @@
     - xarm_api->topic: __joint_states__
 
 ## srv
-- __~~xxxxxx~~ indicates a renamed method, which is compatible with the old method, but the new method is recommended.__
+
 - [xarm_msgs::srv::Call](./srv/Call.srv)
     - xarm_api->service: __clean_error__
     - xarm_api->service: __clean_warn__
@@ -23,15 +23,9 @@
     - xarm_api->service: __clean_bio_gripper_error__
     - xarm_api->service: __start_record_trajectory__
     - xarm_api->service: __stop_record_trajectory__
-    - xarm_api->service: ~~ft_sensor_set_zero~~
-        - please use __set_ft_sensor_zero__ instead
-    - xarm_api->service: __set_ft_sensor_zero__
-    - xarm_api->service: ~~set_linear_track_stop~~
-        - please use __set_linear_motor_stop__ instead
-    - xarm_api->service: __set_linear_motor_stop__
-    - xarm_api->service: ~~clean_linear_track_error~~
-        - please use __clean_linear_motor_error__ instead
-    - xarm_api->service: __clean_linear_motor_error__
+    - xarm_api->service: __ft_sensor_set_zero__
+    - xarm_api->service: __set_linear_track_stop__
+    - xarm_api->service: __clean_linear_track_error__
     - xarm_api->service: __open_lite6_gripper__
     - xarm_api->service: __close_lite6_gripper__
     - xarm_api->service: __stop_lite6_gripper__
@@ -45,35 +39,19 @@
     - xarm_api->service: __get_bio_gripper_error__
     - xarm_api->service: __get_reduced_mode__
     - xarm_api->service: __get_report_tau_or_i__
-    - xarm_api->service: ~~ft_sensor_app_get~~
-        - please use __get_ft_sensor_mode__ instead
-    - xarm_api->service: __get_ft_sensor_mode__
+    - xarm_api->service: __ft_sensor_app_get__
     - xarm_api->service: __get_ft_sensor_error__
     - xarm_api->service: __get_trajectory_rw_status__
-    - xarm_api->service: ~~get_linear_track_pos~~
-        - please use __get_linear_motor_pos__ instead
-    - xarm_api->service: __get_linear_motor_pos__
-    - xarm_api->service: ~~get_linear_track_status~~
-        - please use __get_linear_motor_status__ instead
-    - xarm_api->service: __get_linear_motor_status__
-    - xarm_api->service: ~~get_linear_track_error~~
-        - please use __get_linear_motor_error__ instead
-    - xarm_api->service: __get_linear_motor_error__
-    - xarm_api->service: ~~get_linear_track_is_enabled~~
-        - please use __get_linear_motor_is_enabled__ instead
-    - xarm_api->service: __get_linear_motor_is_enabled__
-    - xarm_api->service: ~~get_linear_track_on_zero~~
-        - please use __get_linear_motor_on_zero__ instead
-    - xarm_api->service: __get_linear_motor_on_zero__
-    - xarm_api->service: ~~get_linear_track_sci~~
-        - please use __get_linear_motor_sci__ instead
-    - xarm_api->service: __get_linear_motor_sci__
+    - xarm_api->service: __get_linear_track_pos__
+    - xarm_api->service: __get_linear_track_status__
+    - xarm_api->service: __get_linear_track_error__
+    - xarm_api->service: __get_linear_track_is_enabled__
+    - xarm_api->service: __get_linear_track_on_zero__
+    - xarm_api->service: __get_linear_track_sci__
 
 - [xarm_msgs::srv::GetInt16List](./srv/GetInt16List.srv)
     - xarm_api->service: __get_err_warn_code__
-    - xarm_api->service: ~~get_linear_track_sco~~
-        - please use __get_linear_motor_sco__ instead
-    - xarm_api->service: __get_linear_motor_sco__
+    - xarm_api->service: __get_linear_track_sco__
 
 - [xarm_msgs::srv::SetInt16](./srv/SetInt16.srv)
     - xarm_api->service: __set_mode__
@@ -89,18 +67,10 @@
     - xarm_api->service: __set_simulation_robot__
     - xarm_api->service: __set_baud_checkset_enable__
     - xarm_api->service: __set_report_tau_or_i__
-    - xarm_api->service: ~~ft_sensor_enable~~
-        - please use __set_ft_sensor_enable__ instead
-    - xarm_api->service: __set_ft_sensor_enable__
-    - xarm_api->service: ~~ft_sensor_app_set~~
-        - please use __set_ft_sensor_mode__ instead
-    - xarm_api->service: __set_ft_sensor_mode__
-    - xarm_api->service: ~~set_linear_track_enable~~
-        - please use __set_linear_motor_enable__ instead
-    - xarm_api->service: __set_linear_motor_enable__
-    - xarm_api->service: ~~set_linear_track_speed~~
-        - please use __set_linear_motor_speed__ instead
-    - xarm_api->service: __set_linear_motor_speed__
+    - xarm_api->service: __ft_sensor_enable__
+    - xarm_api->service: __ft_sensor_app_set__
+    - xarm_api->service: __set_linear_track_enable__
+    - xarm_api->service: __set_linear_track_speed__
     - xarm_api->service: __set_cartesian_velo_continuous__
     - xarm_api->service: __set_allow_approx_motion__
     - xarm_api->service: __set_only_check_type__
@@ -230,50 +200,27 @@
 
 - [xarm_msgs::srv::IdenLoad](./srv/IdenLoad.srv)
     - xarm_api->service: __iden_tcp_load__
-    - xarm_api->service: ~~ft_sensor_iden_load~~
-        - please use __iden_ft_sensor_load_offset__ instead
-    - xarm_api->service: __iden_ft_sensor_load_offset__
+    - xarm_api->service: __ft_sensor_iden_load__
 
 - [xarm_msgs::srv::FtCaliLoad](./srv/FtCaliLoad.srv)
-    - xarm_api->service: ~~ft_sensor_cali_load~~
-        - please use __set_ft_sensor_load_offset__ instead
-    - xarm_api->service: __set_ft_sensor_load_offset__
+    - xarm_api->service: __ft_sensor_cali_load__
 
-- ~~[xarm_msgs::srv::FtForceConfig](./srv/FtForceConfig.srv)~~
-    - xarm_api->service: ~~config_force_control~~
-        - please use __xarm_msgs::srv::FtForceParams__ and __set_ft_sensor_force_parameters__ instead
+- [xarm_msgs::srv::FtForceConfig](./srv/FtForceConfig.srv)
+    - xarm_api->service: __config_force_control__
 
-- ~~[xarm_msgs::srv::FtForcePid](./srv/FtForcePid.srv)~~
-    - xarm_api->service: ~~set_force_control_pid~~
-        - please use __xarm_msgs::srv::FtForceParams__ and __set_ft_sensor_force_parameters__ instead
+- [xarm_msgs::srv::FtForcePid](./srv/FtForcePid.srv)
+    - xarm_api->service: __set_force_control_pid__
 
-- [xarm_msgs::srv::FtForceParams](./srv/FtForceParams.srv)
-    - xarm_api->service: __set_ft_sensor_force_parameters__
+- [xarm_msgs::srv::FtImpedance](./srv/FtImpedance.srv)
+    - xarm_api->service: __set_impedance__
+    - xarm_api->service: __set_impedance_mbk__
+    - xarm_api->service: __set_impedance_config__
 
-- ~~[xarm_msgs::srv::FtImpedance](./srv/FtImpedance.srv)~~
-    - xarm_api->service: ~~set_impedance~~
-        - please use __xarm_msgs::srv::FtAdmittanceParams__ and __set_ft_sensor_admittance_parameters__ instead
-    - xarm_api->service: ~~set_impedance_mbk~~
-        - please use __xarm_msgs::srv::FtAdmittanceParams__ and __set_ft_sensor_admittance_parameters__ instead
-    - xarm_api->service: ~~set_impedance_config~~
-        - please use __xarm_msgs::srv::FtAdmittanceParams__ and __set_ft_sensor_admittance_parameters__ instead
+- [xarm_msgs::srv::LinearTrackBackOrigin](./srv/LinearTrackBackOrigin.srv)
+    - xarm_api->service: __set_linear_track_back_origin__
 
-- [xarm_msgs::srv::FtAdmittanceParams](./srv/FtAdmittanceParams.srv)
-    - xarm_api->service: __set_ft_sensor_admittance_parameters__
-
-- ~~[xarm_msgs::srv::LinearTrackBackOrigin](./srv/LinearTrackBackOrigin.srv)~~
-    - xarm_api->service: ~~set_linear_track_back_origin~~
-        - please use __xarm_msgs::srv::LinearMotorBackOrigin__ and __set_linear_motor_back_origin__ instead
-
-- [xarm_msgs::srv::LinearMotorBackOrigin](./srv/LinearMotorBackOrigin.srv)
-    - xarm_api->service: __set_linear_motor_back_origin__
-
-- ~~[xarm_msgs::srv::LinearTrackSetPos](./srv/LinearTrackSetPos.srv)~~
-    - xarm_api->service: ~~set_linear_track_pos~~
-        - please use __xarm_msgs::srv::LinearMotorSetPos__ and __set_linear_motor_pos__ instead
-
-- [xarm_msgs::srv::LinearMotorSetPos](./srv/LinearMotorSetPos.srv)
-    - xarm_api->service: __set_linear_motor_pos__
+- [xarm_msgs::srv::LinearTrackSetPos](./srv/LinearTrackSetPos.srv)
+    - xarm_api->service: __set_linear_track_pos__
 
 - [xarm_msgs::srv::PlanPose](./srv/PlanPose.srv)
     - xarm_planner->service: __xarm_pose_plan__

--- a/xarm_msgs/srv/Call.srv
+++ b/xarm_msgs/srv/Call.srv
@@ -10,9 +10,9 @@
 #   - clean_bio_gripper_error
 #   - start_record_trajectory
 #   - stop_record_trajectory
-#   - set_ft_sensor_zero        # The old name is ft_sensor_set_zero, please use the new one
-#   - set_linear_motor_stop     # The old name is set_linear_track_stop, please use the new one
-#   - clean_linear_motor_error  # The old name is clean_linear_track_error, please use the new one
+#   - ft_sensor_set_zero
+#   - set_linear_track_stop
+#   - clean_linear_track_error
 #   - open_lite6_gripper
 #   - close_lite6_gripper
 #   - stop_lite6_gripper

--- a/xarm_msgs/srv/FtCaliLoad.srv
+++ b/xarm_msgs/srv/FtCaliLoad.srv
@@ -1,12 +1,12 @@
 # This format is suitable for the following services
-#   - set_ft_sensor_load_offset     # The old name is ft_sensor_cali_load, please use the new one
+#   - ft_sensor_cali_load
 
 # iden result([mass(kg)，x_centroid(mm)，y_centroid(mm)，z_centroid(mm)，Fx_offset，Fy_offset，Fz_offset，Tx_offset，Ty_offset，Tz_ffset])
 float32[] datas
 
 # whether to convert the paramster to the corresponding tcp load and set, default is false
 bool association_setting_tcp_load   false
-float32 m   0.270
+float32 m   0.325
 float32 x   -17.0
 float32 y   9.0
 float32 z   11.8

--- a/xarm_msgs/srv/FtForceConfig.srv
+++ b/xarm_msgs/srv/FtForceConfig.srv
@@ -1,14 +1,9 @@
-# please use FtForceParams instead
 # This format is suitable for the following services
-#   - config_force_control  # please use set_ft_sensor_force_parameters instead
+#   - config_force_control
 
-# task frame (0: base frame. 1: tool frame)
 int16 coord
-# a 6d vector of 0s and 1s. 1 means that robot will be compliant in the corresponding axis of the task frame.
 int16[] c_axis
-# 6d vector, the forces/torques the robot will apply to its environment. The robot adjusts its position along/about compliant axis in order to achieve the specified force/torque.
 float32[] ref
-# 6d vector, for compliant axes, these values are the maximum allowed tcp speed along/about the axis.
 float32[] limits
 
 ---

--- a/xarm_msgs/srv/FtForcePid.srv
+++ b/xarm_msgs/srv/FtForcePid.srv
@@ -1,14 +1,9 @@
-# please use FtForceParams instead
 # This format is suitable for the following services
-#   - set_force_control_pid     # please use set_ft_sensor_force_parameters instead
+#   - set_force_control_pid
 
-# 6d vector, proportional gain.
 float32[] kp
-# 6d vector, integral gain.
 float32[] ki
-# 6d vector, differential gain.
 float32[] kd
-# 6d vector. for compliant axes, these values are the maximum allowed tcp speed along/about the axis. mm/s
 float32[] xe_limit
 
 ---

--- a/xarm_msgs/srv/FtImpedance.srv
+++ b/xarm_msgs/srv/FtImpedance.srv
@@ -1,23 +1,17 @@
-# please use FtAdmittanceParams instead
 # This format is suitable for the following services
-#   - set_impedance         # please use set_ft_sensor_admittance_parameters instead
-#   - set_impedance_config  # please use set_ft_sensor_admittance_parameters instead
-#   - set_impedance_mbk     # please use set_ft_sensor_admittance_parameters instead
+#   - set_impedance
+#   - set_impedance_mbk
+#   - set_impedance_config
 
 #   - set_impedance
 #   - set_impedance_config
-# task frame (0: base frame. 1: tool frame)
 int16 coord
-# a 6d vector of 0s and 1s. 1 means that robot will be admittance in the corresponding axis of the task frame.
 int16[] c_axis
 
 #   - set_impedance
 #   - set_impedance_mbk
-# 6d vector, mass. (kg)
 float32[] m
-# 6d vector, stiffness coefficient
 float32[] k
-# 6d vector, damping coefficient
 float32[] b
 
 ---

--- a/xarm_msgs/srv/GetInt16.srv
+++ b/xarm_msgs/srv/GetInt16.srv
@@ -7,15 +7,15 @@
 #   - get_bio_gripper_error
 #   - get_reduced_mode
 #   - get_report_tau_or_i
-#   - get_ft_sensor_mode            # The old name is ft_sensor_app_get, please use the new one
+#   - ft_sensor_app_get
 #   - get_ft_sensor_error
 #   - get_trajectory_rw_status
-#   - get_linear_motor_pos          # The old name is get_linear_track_pos, please use the new one
-#   - get_linear_motor_status       # The old name is get_linear_track_status, please use the new one
-#   - get_linear_motor_error        # The old name is get_linear_track_error, please use the new one
-#   - get_linear_motor_is_enabled   # The old name is get_linear_track_is_enabled, please use the new one
-#   - get_linear_motor_on_zero      # The old name is get_linear_track_on_zero, please use the new one
-#   - get_linear_motor_sci          # The old name is get_linear_track_sci, please use the new one
+#   - get_linear_track_pos
+#   - get_linear_track_status
+#   - get_linear_track_error
+#   - get_linear_track_is_enabled
+#   - get_linear_track_on_zero
+#   - get_linear_track_sci
 
 ---
 

--- a/xarm_msgs/srv/GetInt16List.srv
+++ b/xarm_msgs/srv/GetInt16List.srv
@@ -1,6 +1,6 @@
 # This format is suitable for the following services
 #   - get_err_warn_code
-#   - get_linear_motor_sco  # The old name is get_linear_track_sco, please use the new one
+#   - get_linear_track_sco
 
 ---
 

--- a/xarm_msgs/srv/IdenLoad.srv
+++ b/xarm_msgs/srv/IdenLoad.srv
@@ -1,6 +1,6 @@
 # This format is suitable for the following services
 #   - iden_tcp_load
-#   - iden_ft_sensor_load_offset   # The old name is ft_sensor_iden_load, please use the new one
+#   - ft_sensor_iden_load
 
 # estimated mass(kg), only required for Lite6 models via the `iden_tcp_load` service
 float32 estimated_mass 0.0
@@ -12,5 +12,5 @@ string message
 
 # the result of identification
 #   iden_tcp_load: [mass(kg)，x_centroid(mm)，y_centroid(mm)，z_centroid(mm)]
-#   iden_ft_sensor_load_offset: [mass(kg)，x_centroid(mm)，y_centroid(mm)，z_centroid(mm)，Fx_offset，Fy_offset，Fz_offset，Tx_offset，Ty_offset，Tz_ffset]
+#   ft_sensor_iden_load: [mass(kg)，x_centroid(mm)，y_centroid(mm)，z_centroid(mm)，Fx_offset，Fy_offset，Fz_offset，Tx_offset，Ty_offset，Tz_ffset]
 float32[] datas

--- a/xarm_msgs/srv/LinearTrackBackOrigin.srv
+++ b/xarm_msgs/srv/LinearTrackBackOrigin.srv
@@ -1,6 +1,5 @@
-# Has been renamed, please use LinearMotorBackOrigin instead
 # This format is suitable for the following services
-#   - set_linear_motor_back_origin  # The old name is set_linear_track_back_origin, please use the new one
+#   - set_linear_track_back_origin
 
 bool wait           true
 bool auto_enable     true

--- a/xarm_msgs/srv/LinearTrackSetPos.srv
+++ b/xarm_msgs/srv/LinearTrackSetPos.srv
@@ -1,6 +1,5 @@
-# Has been renamed, please use LinearMotorSetPos instead
 # This format is suitable for the following services
-#   - set_linear_motor_pos  # The old name is set_linear_track_pos, please use the new one
+#   - set_linear_track_pos
 
 int16 pos
 int16 speed         0

--- a/xarm_msgs/srv/SetInt16.srv
+++ b/xarm_msgs/srv/SetInt16.srv
@@ -12,10 +12,10 @@
 #   - set_simulation_robot
 #   - set_baud_checkset_enable
 #   - set_report_tau_or_i
-#   - set_ft_sensor_enable      # The old name is ft_sensor_enable, please use the new one
-#   - set_ft_sensor_mode        # The old name is ft_sensor_app_set, please use the new one
-#   - set_linear_motor_enable   # The old name is set_linear_track_enable, please use the new one
-#   - set_linear_motor_speed    # The old name is set_linear_track_speed, please use the new one
+#   - ft_sensor_enable
+#   - ft_sensor_app_set
+#   - set_linear_track_enable
+#   - set_linear_track_speed
 #   - set_cartesian_velo_continuous
 #   - set_allow_approx_motion
 #   - set_only_check_type


### PR DESCRIPTION
MoveIt complains about the `continous` joints not being in the `/joint_states` topics. This PR adds `wheels_*` joints inside `joint_broadcaster_controller` under `extra_jpints` and publishes 0 angles for each wheel joints. 

Referece: https://github.com/ros-controls/ros2_controllers/blob/master/joint_state_broadcaster/src/joint_state_broadcaster_parameters.yaml