### PR TITLE
Add a web-control REST bridge for xArm (xarm_bridge, xarm_skills_msgs)

### DIFF
--- a/xarm_bridge/LICENSE
+++ b/xarm_bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ryan Cunningham
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/xarm_bridge/README.md
+++ b/xarm_bridge/README.md
@@ -1,0 +1,83 @@
+# xarm_bridge
+
+A FastAPI REST bridge and `rosbridge_server` launch for web control of a
+single xArm. It turns the ROS 2 action interfaces in `xarm_skills_msgs`
+into a typed HTTP API with persistent job tracking, and exposes a curated,
+telemetry-only WebSocket allowlist for a browser client.
+
+## Highlights
+
+- **Auto-discovery.** At startup the bridge scans `xarm_skills_msgs.action`
+  for action types (anything with `Goal`/`Result`/`Feedback`) and generates
+  a typed Pydantic request model plus a `POST /skills/{name}/run` endpoint
+  for each. Adding a new `.action` file and rebuilding exposes it through
+  the bridge with no code changes here.
+- **Persistent jobs.** Job state (queued / running / succeeded / failed /
+  canceled), feedback, and results are stored in SQLite so they survive a
+  restart.
+- **Telemetry fan-out.** Job feedback is also published to `/job_feedback`
+  (`std_msgs/String`, JSON) for web telemetry over rosbridge.
+- **Auth + CORS.** Set `XARM_BRIDGE_API_KEY` to require an `X-API-Key`
+  header on all mutating endpoints; set `XARM_BRIDGE_CORS_ORIGINS`
+  (comma-separated) to restrict CORS.
+
+## Layout
+
+```
+xarm_bridge/
+├── README.md                       — this file
+├── LICENSE                         — MIT
+├── package.xml / setup.py          — ament_python package metadata
+├── xarm_bridge/
+│   └── bridge_node.py              — FastAPI bridge node
+├── launch/
+│   └── bridge.launch.py            — bridge + rosbridge_server
+└── config/
+    ├── bridge_params.yaml          — node parameters
+    └── rosbridge_allowlist.yaml    — telemetry-only topic allowlist
+```
+
+## Dependencies
+
+- `rclpy`, `std_msgs`
+- `xarm_skills_msgs` (the action interfaces — travels with this contribution)
+- `rosbridge_server`
+- Python: `fastapi`, `uvicorn`, `pydantic`
+
+## Build
+
+```bash
+cd <your_ros2_ws>
+colcon build --packages-select xarm_skills_msgs xarm_bridge
+source install/setup.bash
+```
+
+## Run
+
+```bash
+ros2 launch xarm_bridge bridge.launch.py
+```
+
+This starts the FastAPI bridge on `:8000` and `rosbridge_server` on `:9090`.
+Override ports with `bridge_port:=` / `rosbridge_port:=`.
+
+## API
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/skills` | GET | List discovered skills with typed goal/result schemas |
+| `/skills/{name}/run` | POST | Start a skill (typed body) → `{job_id}` |
+| `/jobs/{id}` | GET | Job status, feedback, result |
+| `/jobs` | GET | Recent jobs |
+| `/jobs/{id}/cancel` | POST | Cancel a running job |
+| `/estop` | POST | Emergency stop — latches `/estop` and cancels active goals |
+| `/confirm` | POST | Confirm a pending `WaitForUser` prompt |
+| `/healthz` | GET | Health + discovered skills |
+| `/openapi.json` | GET | Auto-generated OpenAPI spec |
+
+## rosbridge (telemetry only)
+
+`config/rosbridge_allowlist.yaml` exposes only a small, stable set of
+telemetry topics (joint states, TF, vision, prompts, job feedback) to the
+web client. Command topics are deliberately excluded — all mutations go
+through the authenticated REST bridge above.

--- a/xarm_bridge/config/bridge_params.yaml
+++ b/xarm_bridge/config/bridge_params.yaml
@@ -1,0 +1,9 @@
+bridge_node:
+  ros__parameters:
+    host: "0.0.0.0"
+    port: 8000
+    db_path: "/tmp/xarm_bridge_jobs.db"
+    estop_topic: "/estop"
+    prompt_topic: "/skill_prompts"
+    prompt_confirm_topic: "/skill_prompts/confirm"
+    job_feedback_topic: "/job_feedback"

--- a/xarm_bridge/config/rosbridge_allowlist.yaml
+++ b/xarm_bridge/config/rosbridge_allowlist.yaml
@@ -1,0 +1,14 @@
+rosbridge_websocket:
+  ros__parameters:
+    topics_glob:
+      - "/joint_states"
+      - "/tf"
+      - "/tf_static"
+      - "/vision/objects"
+      - "/vision/annotated_image"
+      - "/skill_prompts"
+      - "/job_feedback"
+    services_glob:
+      - ""
+    params_glob:
+      - ""

--- a/xarm_bridge/config/rosbridge_allowlist.yaml
+++ b/xarm_bridge/config/rosbridge_allowlist.yaml
@@ -1,14 +1,5 @@
 rosbridge_websocket:
   ros__parameters:
-    topics_glob:
-      - "/joint_states"
-      - "/tf"
-      - "/tf_static"
-      - "/vision/objects"
-      - "/vision/annotated_image"
-      - "/skill_prompts"
-      - "/job_feedback"
-    services_glob:
-      - ""
-    params_glob:
-      - ""
+    topics_glob: "[/joint_states, /tf, /tf_static, /vision/objects, /vision/annotated_image, /skill_prompts, /job_feedback]"
+    services_glob: "[]"
+    params_glob: "[]"

--- a/xarm_bridge/launch/bridge.launch.py
+++ b/xarm_bridge/launch/bridge.launch.py
@@ -1,0 +1,49 @@
+"""
+Bridge launch file.
+
+Starts:
+  1. FastAPI bridge node (skill RPC at :8000)
+  2. rosbridge_server (telemetry WebSocket at :9090)
+"""
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+
+def generate_launch_description():
+    bridge_dir = get_package_share_directory("xarm_bridge")
+
+    bridge_params = os.path.join(bridge_dir, "config", "bridge_params.yaml")
+    rosbridge_params = os.path.join(bridge_dir, "config", "rosbridge_allowlist.yaml")
+
+    return LaunchDescription([
+        DeclareLaunchArgument("bridge_port", default_value="8000"),
+        DeclareLaunchArgument("rosbridge_port", default_value="9090"),
+
+        Node(
+            package="xarm_bridge",
+            executable="bridge_node",
+            name="bridge_node",
+            parameters=[
+                bridge_params,
+                {"port": LaunchConfiguration("bridge_port")},
+            ],
+            output="screen",
+        ),
+
+        Node(
+            package="rosbridge_server",
+            executable="rosbridge_websocket",
+            name="rosbridge_websocket",
+            parameters=[
+                rosbridge_params,
+                {"port": LaunchConfiguration("rosbridge_port")},
+            ],
+            output="screen",
+        ),
+    ])

--- a/xarm_bridge/package.xml
+++ b/xarm_bridge/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>xarm_bridge</name>
+  <version>0.1.0</version>
+  <description>
+    FastAPI REST bridge and rosbridge launch for web control of an xArm.
+    Auto-discovers ROS 2 action types from xarm_skills_msgs and exposes
+    each as a typed REST endpoint, with SQLite-backed job persistence and
+    a telemetry-only rosbridge allowlist.
+  </description>
+  <maintainer email="Ryan-Cunningham_EZAG@users.noreply.github.com">Ryan Cunningham</maintainer>
+  <license>MIT</license>
+  <url type="repository">https://github.com/xArm-Developer/xarm_ros2</url>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <depend>rclpy</depend>
+  <depend>xarm_skills_msgs</depend>
+  <depend>std_msgs</depend>
+
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>python3-fastapi</exec_depend>
+  <exec_depend>python3-uvicorn</exec_depend>
+  <exec_depend>python3-pydantic</exec_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/xarm_bridge/setup.cfg
+++ b/xarm_bridge/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/xarm_bridge
+[install]
+install_scripts=$base/lib/xarm_bridge

--- a/xarm_bridge/setup.py
+++ b/xarm_bridge/setup.py
@@ -1,0 +1,32 @@
+from setuptools import setup, find_packages
+
+package_name = "xarm_bridge"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=find_packages(exclude=["test"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+        ("share/" + package_name + "/config", [
+            "config/bridge_params.yaml",
+            "config/rosbridge_allowlist.yaml",
+        ]),
+        ("share/" + package_name + "/launch", [
+            "launch/bridge.launch.py",
+        ]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Ryan Cunningham",
+    maintainer_email="Ryan-Cunningham_EZAG@users.noreply.github.com",
+    description="FastAPI REST bridge and rosbridge launch for xArm web control",
+    license="MIT",
+    url="https://github.com/xArm-Developer/xarm_ros2",
+    entry_points={
+        "console_scripts": [
+            "bridge_node = xarm_bridge.bridge_node:main",
+        ],
+    },
+)

--- a/xarm_bridge/xarm_bridge/bridge_node.py
+++ b/xarm_bridge/xarm_bridge/bridge_node.py
@@ -1,0 +1,731 @@
+"""
+FastAPI bridge node for xArm skill RPC.
+
+Runs a FastAPI HTTP server inside a ROS 2 node. At startup it dynamically
+discovers all action types from the xarm_skills_msgs.action module by
+scanning for classes with Goal/Result/Feedback inner types. For each
+discovered action it auto-generates:
+
+  - A typed Pydantic Goal model (from ROS Goal field introspection)
+  - A typed Pydantic Result model
+  - A REST endpoint: POST /skills/{name}/run
+
+Adding a new .action file to xarm_skills_msgs and rebuilding will
+automatically expose it through the bridge without any code changes here.
+
+Other endpoints:
+  GET  /skills              — list discovered skills with typed schemas
+  GET  /jobs/{job_id}       — poll job status / feedback / result
+  GET  /jobs                — list recent jobs
+  POST /jobs/{job_id}/cancel — cancel a running job
+  POST /estop               — emergency stop (publishes to /estop topic)
+  POST /confirm             — confirm a WaitForUser prompt
+  GET  /healthz             — health check
+  GET  /openapi.json        — auto-generated OpenAPI spec
+
+Job state is persisted in a SQLite database so it survives restarts.
+Job feedback is also published to /job_feedback (String, JSON) for
+web telemetry via rosbridge.
+
+Authentication: If XARM_BRIDGE_API_KEY env var is set, all mutating
+endpoints require X-API-Key header. Set XARM_BRIDGE_CORS_ORIGINS to
+restrict CORS (comma-separated origins).
+"""
+
+import asyncio
+import importlib
+import inspect
+import json
+import os
+import re
+import sqlite3
+import threading
+import time
+import uuid
+from enum import Enum
+from typing import Any, Optional
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from rclpy.callback_group import ReentrantCallbackGroup
+from rclpy.qos import QoSProfile, DurabilityPolicy, ReliabilityPolicy
+from std_msgs.msg import Bool, String
+
+try:
+    from fastapi import FastAPI, HTTPException, Depends
+    from fastapi.middleware.cors import CORSMiddleware
+    from fastapi.security import APIKeyHeader
+    from pydantic import BaseModel, create_model
+    import uvicorn
+    HAS_FASTAPI = True
+except ImportError:
+    HAS_FASTAPI = False
+
+
+def _camel_to_snake(name):
+    """Convert CamelCase to snake_case."""
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _is_ros_action_type(obj):
+    """Check if an object is a ROS 2 action type (has Goal, Result, Feedback)."""
+    return (
+        inspect.isclass(obj)
+        and hasattr(obj, "Goal")
+        and hasattr(obj, "Result")
+        and hasattr(obj, "Feedback")
+        and hasattr(obj.Goal, "get_fields_and_field_types")
+    )
+
+
+def discover_skills(package_name="xarm_skills_msgs.action"):
+    """Dynamically discover all action types from a ROS 2 msgs package.
+
+    Scans the given package module for classes that have Goal/Result/Feedback
+    inner types (i.e., ROS 2 action types). Returns a dict mapping
+    snake_case skill names to their action type classes.
+
+    Adding a new .action file to xarm_skills_msgs and rebuilding will
+    cause it to appear here automatically.
+    """
+    try:
+        module = importlib.import_module(package_name)
+    except ImportError as e:
+        print("WARNING: Could not import %s: %s" % (package_name, e))
+        return {}
+
+    discovered = {}
+    for attr_name in dir(module):
+        obj = getattr(module, attr_name)
+        if _is_ros_action_type(obj):
+            skill_name = _camel_to_snake(attr_name)
+            discovered[skill_name] = {
+                "action_type": obj,
+                "action_name": skill_name,
+                "class_name": attr_name,
+            }
+
+    return discovered
+
+
+def _ros_field_to_pydantic(field_name, ros_type_str, goal_cls):
+    """Convert a ROS 2 field type to a Pydantic field tuple (type, default)."""
+    goal_instance = goal_cls()
+
+    if ros_type_str in ("string",):
+        default = getattr(goal_instance, field_name, "")
+        if default == "":
+            return (str, ...)
+        return (str, default)
+
+    if ros_type_str in ("float64", "float32"):
+        default = getattr(goal_instance, field_name, 0.0)
+        return (float, default)
+
+    if ros_type_str in ("int32", "int64", "uint32", "uint16", "uint8"):
+        default = getattr(goal_instance, field_name, 0)
+        return (int, default)
+
+    if ros_type_str in ("bool", "boolean"):
+        default = getattr(goal_instance, field_name, False)
+        return (bool, default)
+
+    if "sequence" in ros_type_str:
+        return (list[dict], ...)
+
+    return (Any, None)
+
+
+def _build_pydantic_models(skill_name, action_type):
+    """Build typed Pydantic Goal and Result models from ROS action type."""
+    goal_cls = action_type.Goal
+    goal_fields = goal_cls.get_fields_and_field_types()
+
+    pydantic_fields = {}
+    for fname, ftype in goal_fields.items():
+        pydantic_fields[fname] = _ros_field_to_pydantic(fname, ftype, goal_cls)
+
+    GoalModel = create_model(
+        "%sGoal" % skill_name.title().replace("_", ""),
+        **pydantic_fields,
+    )
+
+    result_cls = action_type.Result
+    result_fields_raw = result_cls.get_fields_and_field_types()
+    result_pydantic = {}
+    for fname, ftype in result_fields_raw.items():
+        if ftype in ("string",):
+            result_pydantic[fname] = (Optional[str], None)
+        elif ftype in ("float64", "float32"):
+            result_pydantic[fname] = (Optional[float], None)
+        elif ftype in ("int32", "int64"):
+            result_pydantic[fname] = (Optional[int], None)
+        elif ftype in ("bool", "boolean"):
+            result_pydantic[fname] = (Optional[bool], None)
+        else:
+            result_pydantic[fname] = (Any, None)
+
+    ResultModel = create_model(
+        "%sResult" % skill_name.title().replace("_", ""),
+        **result_pydantic,
+    )
+
+    return GoalModel, ResultModel
+
+
+def _build_goal_schema(action_type):
+    """Build a JSON-serializable schema of the goal fields."""
+    goal_cls = action_type.Goal
+    fields = goal_cls.get_fields_and_field_types()
+    goal_instance = goal_cls()
+    schema = {}
+    for fname, ftype in fields.items():
+        entry = {"ros_type": ftype}
+        default = getattr(goal_instance, fname, None)
+        if ftype == "string":
+            entry["type"] = "string"
+            if default and default != "":
+                entry["default"] = default
+            else:
+                entry["required"] = True
+        elif ftype in ("float64", "float32"):
+            entry["type"] = "number"
+            entry["default"] = float(default) if default else 0.0
+        elif ftype in ("int32", "int64"):
+            entry["type"] = "integer"
+            entry["default"] = int(default) if default else 0
+        elif ftype in ("bool", "boolean"):
+            entry["type"] = "boolean"
+            entry["default"] = bool(default)
+        elif "sequence" in ftype:
+            entry["type"] = "array"
+            entry["required"] = True
+        else:
+            entry["type"] = "any"
+        schema[fname] = entry
+    return schema
+
+
+def _convert_sequence_field(field_type, value):
+    """Convert JSON list to ROS message list for sequence fields."""
+    if "geometry_msgs/Point" in field_type and isinstance(value, list):
+        from geometry_msgs.msg import Point
+        pts = []
+        for wp in value:
+            p = Point()
+            p.x = float(wp.get("x", 0.0))
+            p.y = float(wp.get("y", 0.0))
+            p.z = float(wp.get("z", 0.0))
+            pts.append(p)
+        return pts
+    return value
+
+
+class JobStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+
+class JobDB:
+    """SQLite-backed job persistence."""
+
+    def __init__(self, db_path):
+        self._db_path = db_path
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _init_db(self):
+        with self._lock:
+            conn = sqlite3.connect(self._db_path)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS jobs (
+                    id TEXT PRIMARY KEY,
+                    skill_name TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'queued',
+                    goal_json TEXT,
+                    feedback_json TEXT,
+                    result_json TEXT,
+                    created_at REAL,
+                    updated_at REAL
+                )
+            """)
+            conn.commit()
+            conn.close()
+
+    def create_job(self, job_id, skill_name, goal_dict):
+        now = time.time()
+        with self._lock:
+            conn = sqlite3.connect(self._db_path)
+            conn.execute(
+                "INSERT INTO jobs (id, skill_name, status, goal_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (job_id, skill_name, JobStatus.QUEUED, json.dumps(goal_dict), now, now),
+            )
+            conn.commit()
+            conn.close()
+
+    def update_status(self, job_id, status, feedback=None, result=None):
+        now = time.time()
+        with self._lock:
+            conn = sqlite3.connect(self._db_path)
+            updates = ["status = ?", "updated_at = ?"]
+            params = [status, now]
+            if feedback is not None:
+                updates.append("feedback_json = ?")
+                params.append(json.dumps(feedback))
+            if result is not None:
+                updates.append("result_json = ?")
+                params.append(json.dumps(result))
+            params.append(job_id)
+            conn.execute(
+                "UPDATE jobs SET %s WHERE id = ?" % ", ".join(updates),
+                params,
+            )
+            conn.commit()
+            conn.close()
+
+    def get_job(self, job_id):
+        with self._lock:
+            conn = sqlite3.connect(self._db_path)
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+            conn.close()
+            if row is None:
+                return None
+            return dict(row)
+
+    def list_jobs(self, limit=50):
+        with self._lock:
+            conn = sqlite3.connect(self._db_path)
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM jobs ORDER BY created_at DESC LIMIT ?", (limit,)
+            ).fetchall()
+            conn.close()
+            return [dict(r) for r in rows]
+
+
+class BridgeNode(Node):
+    def __init__(self):
+        super().__init__("bridge_node")
+
+        self.declare_parameter("host", "0.0.0.0")
+        self.declare_parameter("port", 8000)
+        self.declare_parameter("db_path", "/tmp/xarm_bridge_jobs.db")
+        self.declare_parameter("estop_topic", "/estop")
+        self.declare_parameter("prompt_confirm_topic", "/skill_prompts/confirm")
+        self.declare_parameter("job_feedback_topic", "/job_feedback")
+        self.declare_parameter("skills_package", "xarm_skills_msgs.action")
+
+        self._cb_group = ReentrantCallbackGroup()
+
+        estop_qos = QoSProfile(
+            depth=1,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=ReliabilityPolicy.RELIABLE,
+        )
+
+        self.estop_pub = self.create_publisher(
+            Bool,
+            self.get_parameter("estop_topic").value,
+            estop_qos,
+        )
+
+        self.confirm_pub = self.create_publisher(
+            Bool,
+            self.get_parameter("prompt_confirm_topic").value,
+            10,
+        )
+
+        self.job_feedback_pub = self.create_publisher(
+            String,
+            self.get_parameter("job_feedback_topic").value,
+            10,
+        )
+
+        self.db = JobDB(self.get_parameter("db_path").value)
+
+        self._action_clients = {}
+        self._active_goal_handles = {}
+        self._goal_lock = threading.Lock()
+
+        self._skill_registry = {}
+        self._skill_models = {}
+
+        skills_package = self.get_parameter("skills_package").value
+        discovered = discover_skills(skills_package)
+
+        for name, info in discovered.items():
+            client = ActionClient(
+                self, info["action_type"], info["action_name"],
+                callback_group=self._cb_group,
+            )
+            self._action_clients[name] = client
+
+            GoalModel, ResultModel = _build_pydantic_models(name, info["action_type"])
+            self._skill_models[name] = {
+                "goal_model": GoalModel,
+                "result_model": ResultModel,
+                "schema": _build_goal_schema(info["action_type"]),
+            }
+
+            self._skill_registry[name] = info
+
+        self.get_logger().info(
+            "Bridge node initialized — discovered %d skills from %s: %s"
+            % (len(self._skill_registry), skills_package, list(self._skill_registry.keys()))
+        )
+
+    def _build_goal(self, skill_name, params):
+        info = self._skill_registry[skill_name]
+        action_type = info["action_type"]
+        goal = action_type.Goal()
+
+        goal_fields = action_type.Goal.get_fields_and_field_types()
+
+        for field_name, field_type in goal_fields.items():
+            if field_name in params:
+                value = params[field_name]
+                if "sequence" in field_type:
+                    value = _convert_sequence_field(field_type, value)
+                setattr(goal, field_name, value)
+
+        return goal
+
+    def _publish_job_feedback(self, job_id, skill_name, feedback_dict):
+        msg = String()
+        msg.data = json.dumps({
+            "job_id": job_id,
+            "skill": skill_name,
+            "feedback": feedback_dict,
+            "timestamp": time.time(),
+        })
+        self.job_feedback_pub.publish(msg)
+
+    def _extract_feedback(self, fb):
+        feedback_dict = {}
+        for attr in dir(fb):
+            if attr.startswith("_") or attr.startswith("SLOT") or callable(getattr(fb, attr)):
+                continue
+            if attr in ("get_fields_and_field_types",):
+                continue
+            try:
+                val = getattr(fb, attr)
+                if isinstance(val, (int, float, str, bool)):
+                    feedback_dict[attr] = val
+            except Exception:
+                pass
+
+        if hasattr(fb, "get_fields_and_field_types"):
+            for fname, ftype in fb.get_fields_and_field_types().items():
+                val = getattr(fb, fname, None)
+                if val is not None:
+                    if ftype in ("float32", "float64"):
+                        feedback_dict[fname] = float(val)
+                    elif ftype in ("int32", "int64"):
+                        feedback_dict[fname] = int(val)
+                    elif ftype == "string":
+                        feedback_dict[fname] = str(val)
+                    elif ftype in ("bool", "boolean"):
+                        feedback_dict[fname] = bool(val)
+                    else:
+                        feedback_dict[fname] = val
+
+        return feedback_dict
+
+    def _extract_result(self, r, action_type):
+        result_fields = action_type.Result.get_fields_and_field_types()
+        result_dict = {}
+        for fname, ftype in result_fields.items():
+            val = getattr(r, fname, None)
+            if val is not None:
+                if ftype in ("bool", "boolean"):
+                    result_dict[fname] = bool(val)
+                elif ftype in ("float64", "float32"):
+                    result_dict[fname] = float(val)
+                elif ftype in ("int32", "int64"):
+                    result_dict[fname] = int(val)
+                elif ftype == "string":
+                    result_dict[fname] = str(val)
+                else:
+                    result_dict[fname] = val
+        return result_dict
+
+    async def start_skill(self, skill_name, params):
+        if skill_name not in self._skill_registry:
+            raise ValueError("Unknown skill: %s" % skill_name)
+
+        client = self._action_clients[skill_name]
+        if not client.wait_for_server(timeout_sec=3.0):
+            raise RuntimeError("Action server '%s' not available" % skill_name)
+
+        goal = self._build_goal(skill_name, params)
+        job_id = str(uuid.uuid4())[:8]
+        action_type = self._skill_registry[skill_name]["action_type"]
+
+        self.db.create_job(job_id, skill_name, params)
+
+        def feedback_cb(feedback_msg):
+            fb = feedback_msg.feedback
+            feedback_dict = self._extract_feedback(fb)
+            self.db.update_status(job_id, JobStatus.RUNNING, feedback=feedback_dict)
+            self._publish_job_feedback(job_id, skill_name, feedback_dict)
+
+        goal_handle_future = await client.send_goal_async(
+            goal, feedback_callback=feedback_cb,
+        )
+
+        if not goal_handle_future.accepted:
+            self.db.update_status(
+                job_id, JobStatus.FAILED,
+                result={"success": False, "message": "Goal rejected by action server"},
+            )
+            return job_id
+
+        self.db.update_status(job_id, JobStatus.RUNNING)
+
+        with self._goal_lock:
+            self._active_goal_handles[job_id] = goal_handle_future
+
+        async def wait_for_result():
+            try:
+                result_resp = await goal_handle_future.get_result_async()
+                r = result_resp.result
+                result_dict = self._extract_result(r, action_type)
+
+                status = JobStatus.SUCCEEDED if getattr(r, "success", True) else JobStatus.FAILED
+                self.db.update_status(job_id, status, result=result_dict)
+
+                completion_msg = String()
+                completion_msg.data = json.dumps({
+                    "job_id": job_id,
+                    "skill": skill_name,
+                    "status": status,
+                    "result": result_dict,
+                    "timestamp": time.time(),
+                })
+                self.job_feedback_pub.publish(completion_msg)
+            except Exception as e:
+                self.db.update_status(
+                    job_id, JobStatus.FAILED,
+                    result={"success": False, "message": str(e)},
+                )
+            finally:
+                with self._goal_lock:
+                    self._active_goal_handles.pop(job_id, None)
+
+        asyncio.ensure_future(wait_for_result())
+        return job_id
+
+    async def cancel_job(self, job_id):
+        with self._goal_lock:
+            goal_handle = self._active_goal_handles.get(job_id)
+        if goal_handle is None:
+            return False
+        await goal_handle.cancel_goal_async()
+        self.db.update_status(job_id, JobStatus.CANCELED)
+        return True
+
+    def trigger_estop(self):
+        msg = Bool()
+        msg.data = True
+        self.estop_pub.publish(msg)
+        self.get_logger().error("E-STOP triggered via bridge")
+
+        with self._goal_lock:
+            for job_id, gh in list(self._active_goal_handles.items()):
+                try:
+                    asyncio.ensure_future(gh.cancel_goal_async())
+                except Exception:
+                    pass
+                self.db.update_status(
+                    job_id, JobStatus.FAILED,
+                    result={"success": False, "message": "E-stop triggered"},
+                )
+            self._active_goal_handles.clear()
+
+    def confirm_prompt(self):
+        msg = Bool()
+        msg.data = True
+        self.confirm_pub.publish(msg)
+
+
+def create_fastapi_app(bridge_node):
+    api_key_env = os.environ.get("XARM_BRIDGE_API_KEY", "")
+    require_auth = bool(api_key_env)
+
+    app = FastAPI(
+        title="xArm Skills Bridge",
+        description="REST API for xArm chemistry lab skill execution. "
+                    "Skills are auto-discovered from xarm_skills_msgs at startup.",
+        version="1.0.0",
+    )
+
+    allowed_origins = os.environ.get("XARM_BRIDGE_CORS_ORIGINS", "")
+    if allowed_origins:
+        origins_list = [o.strip() for o in allowed_origins.split(",")]
+    else:
+        origins_list = ["*"]
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins_list,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+    async def verify_api_key(key: str = Depends(api_key_header)):
+        if not require_auth:
+            return
+        if key != api_key_env:
+            raise HTTPException(status_code=403, detail="Invalid or missing API key")
+
+    class JobResponse(BaseModel):
+        id: str
+        skill_name: str
+        status: str
+        goal: dict | None = None
+        feedback: dict | None = None
+        result: dict | None = None
+        created_at: float | None = None
+        updated_at: float | None = None
+
+    class SkillInfo(BaseModel):
+        name: str
+        action_class: str
+        goal_schema: dict
+        result_fields: dict
+
+    def _job_to_response(j):
+        return JobResponse(
+            id=j["id"],
+            skill_name=j["skill_name"],
+            status=j["status"],
+            goal=json.loads(j["goal_json"]) if j.get("goal_json") else None,
+            feedback=json.loads(j["feedback_json"]) if j.get("feedback_json") else None,
+            result=json.loads(j["result_json"]) if j.get("result_json") else None,
+            created_at=j.get("created_at"),
+            updated_at=j.get("updated_at"),
+        )
+
+    @app.get("/skills", response_model=list[SkillInfo])
+    async def list_skills():
+        result = []
+        for name, info in bridge_node._skill_registry.items():
+            models = bridge_node._skill_models[name]
+            result_fields = info["action_type"].Result.get_fields_and_field_types()
+            result.append(SkillInfo(
+                name=name,
+                action_class=info["class_name"],
+                goal_schema=models["schema"],
+                result_fields=result_fields,
+            ))
+        return result
+
+    for skill_name in list(bridge_node._skill_registry.keys()):
+        info = bridge_node._skill_registry[skill_name]
+        GoalModel = bridge_node._skill_models[skill_name]["goal_model"]
+
+        def _make_run_endpoint(sname, model, cls_name):
+            async def run_skill(body: model, _=Depends(verify_api_key)):
+                try:
+                    params = body.model_dump()
+                    job_id = await bridge_node.start_skill(sname, params)
+                    return {"job_id": job_id}
+                except ValueError as e:
+                    raise HTTPException(status_code=400, detail=str(e))
+                except RuntimeError as e:
+                    raise HTTPException(status_code=503, detail=str(e))
+
+            run_skill.__name__ = "run_%s" % sname
+            run_skill.__doc__ = "Execute the %s skill (auto-discovered from %s)" % (sname, cls_name)
+            return run_skill
+
+        endpoint = _make_run_endpoint(skill_name, GoalModel, info["class_name"])
+        app.post(
+            "/skills/%s/run" % skill_name,
+            summary="Run %s" % skill_name.replace("_", " ").title(),
+            tags=["skills"],
+        )(endpoint)
+
+    @app.get("/jobs/{job_id}", response_model=JobResponse)
+    async def get_job(job_id: str):
+        job = bridge_node.db.get_job(job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail="Job not found")
+        return _job_to_response(job)
+
+    @app.get("/jobs", response_model=list[JobResponse])
+    async def list_jobs(limit: int = 50):
+        jobs = bridge_node.db.list_jobs(limit=limit)
+        return [_job_to_response(j) for j in jobs]
+
+    @app.post("/jobs/{job_id}/cancel")
+    async def cancel_job(job_id: str, _=Depends(verify_api_key)):
+        success = await bridge_node.cancel_job(job_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="No active job with that ID")
+        return {"status": "canceled", "job_id": job_id}
+
+    @app.post("/estop")
+    async def estop(_=Depends(verify_api_key)):
+        bridge_node.trigger_estop()
+        return {"status": "estopped"}
+
+    @app.post("/confirm")
+    async def confirm(_=Depends(verify_api_key)):
+        bridge_node.confirm_prompt()
+        return {"status": "confirmed"}
+
+    @app.get("/healthz")
+    async def healthz():
+        return {
+            "status": "ok",
+            "skills_discovered": list(bridge_node._skill_registry.keys()),
+            "skills_count": len(bridge_node._skill_registry),
+        }
+
+    return app
+
+
+def main(args=None):
+    if not HAS_FASTAPI:
+        print("ERROR: FastAPI not installed. Install with: pip3 install fastapi uvicorn")
+        return
+
+    rclpy.init(args=args)
+    bridge_node = BridgeNode()
+
+    app = create_fastapi_app(bridge_node)
+
+    host = bridge_node.get_parameter("host").value
+    port = bridge_node.get_parameter("port").value
+
+    ros_thread = threading.Thread(
+        target=lambda: rclpy.spin(bridge_node),
+        daemon=True,
+    )
+    ros_thread.start()
+
+    bridge_node.get_logger().info(
+        "FastAPI bridge starting on %s:%d" % (host, port)
+    )
+
+    try:
+        uvicorn.run(app, host=host, port=port, log_level="info")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        bridge_node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/xarm_bridge/xarm_bridge/bridge_node.py
+++ b/xarm_bridge/xarm_bridge/bridge_node.py
@@ -48,7 +48,7 @@ from typing import Any, Optional
 import rclpy
 from rclpy.node import Node
 from rclpy.action import ActionClient
-from rclpy.callback_group import ReentrantCallbackGroup
+from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.qos import QoSProfile, DurabilityPolicy, ReliabilityPolicy
 from std_msgs.msg import Bool, String
 

--- a/xarm_skills_msgs/CMakeLists.txt
+++ b/xarm_skills_msgs/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.8)
+project(xarm_skills_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "action/Stir.action"
+  "action/PickAndPlace.action"
+  "action/Dispense.action"
+  "action/Glue.action"
+  "action/Transfer.action"
+  "action/WaitForUser.action"
+  DEPENDENCIES geometry_msgs
+)
+
+ament_package()

--- a/xarm_skills_msgs/LICENSE
+++ b/xarm_skills_msgs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ryan Cunningham
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/xarm_skills_msgs/README.md
+++ b/xarm_skills_msgs/README.md
@@ -1,0 +1,43 @@
+# xarm_skills_msgs
+
+ROS 2 **action** interfaces for high-level xArm lab-automation skills. These
+are the contract between a web/REST client (via `xarm_bridge`) and the
+action-server implementations that drive the arm.
+
+## Actions
+
+| Action | Goal (summary) | Purpose |
+|---|---|---|
+| `PickAndPlace` | source/destination labels, grasp width, heights | Vision-guided pick from a source and place at a destination |
+| `Transfer` | source/destination labels, safe transit height | Pick a container and move it safely above the bench to a destination |
+| `Dispense` | container label, volume, pump rate | Move to a container and trigger an external pump to dispense N ml |
+| `Stir` | target label, rpm, duration, depth | Locate a container and stir with a gripper-held rod |
+| `Glue` | waypoint path, speed, dispense flag | Follow a waypoint path with a glue tip, triggering a pump between segments |
+| `WaitForUser` | message, timeout | Pause and prompt the operator; resume on confirm or timeout |
+
+Every action follows the same shape: a `Goal` with the parameters above, a
+`Result` with `bool success` + `string message` (plus action-specific
+fields), and `Feedback` with a `float32 progress` and a `string status`.
+
+See the individual files in [`action/`](action) for the exact field
+definitions.
+
+## Dependencies
+
+- `geometry_msgs` (used by `Glue` waypoints)
+- `rosidl_default_generators` / `rosidl_default_runtime`
+
+## Build
+
+```bash
+cd <your_ros2_ws>
+colcon build --packages-select xarm_skills_msgs
+source install/setup.bash
+```
+
+## Adding a skill
+
+1. Add `action/MySkill.action` (Goal `---` Result `---` Feedback).
+2. List it in `CMakeLists.txt` under `rosidl_generate_interfaces`.
+3. Rebuild. `xarm_bridge` auto-discovers the new action and exposes a
+   `POST /skills/my_skill/run` endpoint with no bridge code changes.

--- a/xarm_skills_msgs/action/Dispense.action
+++ b/xarm_skills_msgs/action/Dispense.action
@@ -1,0 +1,15 @@
+# Goal: move to container and trigger external pump for dispensing
+string container_label     # vision label of target container
+float64 volume_ml 1.0      # volume to dispense (milliliters)
+float64 pump_rate_ml_s 0.5 # pump flow rate (ml/s) — used to compute trigger duration
+float64 hover_height_m 0.04  # height above container opening to position nozzle
+---
+# Result
+bool success
+string message
+float64 actual_volume_ml   # estimated volume dispensed
+float64 pump_duration_s    # how long pump was triggered
+---
+# Feedback
+float32 progress
+string status              # "locating_container", "approaching", "dispensing", "retracting"

--- a/xarm_skills_msgs/action/Glue.action
+++ b/xarm_skills_msgs/action/Glue.action
@@ -1,0 +1,16 @@
+# Goal: move gripper-held glue tip along a path of waypoints
+# Each waypoint is a geometry_msgs/Point in base_link frame
+geometry_msgs/Point[] waypoints   # ordered list of XYZ positions (base_link frame)
+float64 speed_m_s 0.01            # end-effector speed along path (m/s)
+float64 approach_height_m 0.05    # height above first waypoint for approach
+bool dispense_between true        # trigger pump GPIO between waypoints
+---
+# Result
+bool success
+string message
+int32 waypoints_completed
+---
+# Feedback
+float32 progress
+string status              # "approaching", "gluing_segment_N", "retracting"
+int32 current_waypoint

--- a/xarm_skills_msgs/action/PickAndPlace.action
+++ b/xarm_skills_msgs/action/PickAndPlace.action
@@ -1,0 +1,14 @@
+# Goal: pick object from source location and place at destination
+string source_label        # vision label of object to pick (e.g. "vial", "apriltag_1")
+string destination_label   # vision label or named pose for placement
+float64 grasp_width_m 0.02    # gripper opening for grasp (meters)
+float64 approach_height_m 0.06 # height above object for approach/depart
+float64 place_height_m 0.01   # height above destination to release
+---
+# Result
+bool success
+string message
+---
+# Feedback
+float32 progress
+string status              # "locating_source", "approaching", "grasping", "lifting", "moving", "placing", "releasing", "departing"

--- a/xarm_skills_msgs/action/Stir.action
+++ b/xarm_skills_msgs/action/Stir.action
@@ -1,0 +1,15 @@
+# Goal: locate target container and stir with gripper-held rod
+string target_label        # vision label or apriltag ID (e.g. "beaker", "apriltag_3")
+float64 rpm 60.0           # approximate stir speed (oscillation rate)
+float64 duration_s 10.0    # how long to stir (seconds)
+float64 depth_m 0.03       # how deep to plunge the stir rod (meters)
+float64 retract_height_m 0.08  # height above container to retract to
+---
+# Result
+bool success
+string message
+float64 actual_duration_s
+---
+# Feedback
+float32 progress           # 0.0 to 1.0
+string status              # e.g. "locating_target", "approaching", "stirring", "retracting"

--- a/xarm_skills_msgs/action/Transfer.action
+++ b/xarm_skills_msgs/action/Transfer.action
@@ -1,0 +1,14 @@
+# Goal: pick container from source, move safely above bench, place at destination
+string source_label        # vision label of container to transfer
+string destination_label   # vision label or named pose for destination
+float64 grasp_width_m 0.02    # gripper opening for grasp
+float64 safe_height_m 0.12    # height above bench for safe transit
+float64 approach_height_m 0.06 # height above object for approach/depart
+---
+# Result
+bool success
+string message
+---
+# Feedback
+float32 progress
+string status              # "locating_source", "grasping", "lifting", "transiting", "placing", "releasing"

--- a/xarm_skills_msgs/action/WaitForUser.action
+++ b/xarm_skills_msgs/action/WaitForUser.action
@@ -1,0 +1,13 @@
+# Goal: pause execution and surface a prompt to the operator
+string message             # message displayed to the user (e.g. "Replace the vial and press Continue")
+float64 timeout_s 0.0      # 0 = wait indefinitely; >0 = auto-resume after timeout
+---
+# Result
+bool success
+string message             # "confirmed" or "timed_out"
+bool user_confirmed        # true if user pressed confirm, false if timed out
+---
+# Feedback
+float32 progress           # 0.0 while waiting, 1.0 on confirm/timeout
+string status              # "waiting_for_user"
+float64 elapsed_s          # seconds elapsed since prompt was shown

--- a/xarm_skills_msgs/package.xml
+++ b/xarm_skills_msgs/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>xarm_skills_msgs</name>
+  <version>0.1.0</version>
+  <description>
+    ROS 2 action interfaces for high-level xArm lab automation skills
+    (pick-and-place, dispense, stir, glue, transfer, wait-for-user).
+    Consumed by xarm_bridge and the action-server implementations.
+  </description>
+  <maintainer email="Ryan-Cunningham_EZAG@users.noreply.github.com">Ryan Cunningham</maintainer>
+  <license>MIT</license>
+  <url type="repository">https://github.com/xArm-Developer/xarm_ros2</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+</package>


### PR DESCRIPTION
## Summary

Adds two additive, self-contained ROS 2 packages that turn an xArm running on
this stack into a typed web-controllable arm without changing any of the
existing `xarm_*` driver / MoveIt / Gazebo packages:

- **`xarm_skills_msgs`** — six skill-level `.action` interfaces
  (`PickAndPlace`, `Transfer`, `Dispense`, `Stir`, `Glue`, `WaitForUser`)
  that represent the actual *tasks* a lab/manufacturing operator wants to
  trigger from a browser (as opposed to raw joint trajectories).
- **`xarm_bridge`** — a `rclpy` node that auto-discovers every action type
  in `xarm_skills_msgs.action`, generates a typed Pydantic schema +
  `POST /skills/{name}/run` REST endpoint for each, persists job state in
  SQLite, and launches alongside `rosbridge_server` on the same launch
  file with a telemetry-only topic allowlist (joint states, TF, vision,
  prompts, job feedback — no command topics, all mutation goes through the
  authenticated REST surface).

Pure addition. Zero edits to any pre-existing package. Both packages live at
the repo root, ament-style.

## Why

There is currently no first-class way to drive an xArm from a web UI
without writing a one-off bridge per project. The Hiwonder LX-series
controllers, the official xArm SDK, and `xarm_api` all expose either raw
joint commands or low-level service calls — useful for ROS-native clients
but a poor fit for a browser that wants to say "PickAndPlace from A to B"
and get back a job id it can poll.

This PR upstreams a generic, reusable bridge:

- The bridge is **declarative** — adding a new `.action` file to
  `xarm_skills_msgs` and rebuilding exposes it as a typed REST endpoint
  with zero bridge-side changes.
- It is **safe by default** — `rosbridge_server` is launched with a
  topic allowlist of telemetry-only topics; the browser cannot publish
  command topics directly. All goal sending happens via the FastAPI side,
  which supports optional `X-API-Key` auth and `CORS` restrictions.
- It is **stateful across restarts** — job state, feedback and results
  are persisted to SQLite (path configurable), so a browser polling a
  job id survives a bridge restart.
- It is **self-contained** — no edits to existing packages; downstream
  users opt in by `colcon build --packages-select`-ing the two new ones.

## Packages

### `xarm_skills_msgs` (new)

`.action` files at `xarm_skills_msgs/action/`:

| Skill | Goal highlights | Result highlights |
|---|---|---|
| `PickAndPlace` | `source_label`, `destination_label`, optional grasp width / heights | `success`, `message` |
| `Transfer` | `source_label`, `destination_label`, optional safe / approach heights | `success`, `message` |
| `Dispense` | `container_label`, `volume_ml`, `pump_rate_ml_s`, `hover_height_m` | `success`, `actual_volume_ml`, `pump_duration_s` |
| `Stir` | `target_label`, `rpm`, `duration_s`, `depth_m`, `retract_height_m` | `success`, `actual_duration_s` |
| `Glue` | `waypoints` (sequence&lt;geometry_msgs/Point&gt;), `speed_m_s`, `approach_height_m`, `dispense_between` | `success`, `waypoints_completed` |
| `WaitForUser` | `message`, optional `timeout_s` | `success`, `user_confirmed` |

CMake-style, `rosidl_default_generators` for codegen, MIT-licensed.

### `xarm_bridge` (new)

`ament_python` package laid out as:

```
xarm_bridge/
├── package.xml / setup.py
├── xarm_bridge/bridge_node.py    — rclpy + FastAPI node
├── launch/bridge.launch.py        — bridge_node + rosbridge_websocket
└── config/
    ├── bridge_params.yaml         — host/port/db_path/topics
    └── rosbridge_allowlist.yaml   — telemetry-only topics_glob
```

| Endpoint | Method | Description |
|---|---|---|
| `/skills` | GET | List discovered skills with typed goal/result schemas |
| `/skills/{name}/run` | POST | Start a skill (typed body) → `{job_id}` |
| `/jobs/{id}` | GET | Job status, feedback, result |
| `/jobs` | GET | Recent jobs |
| `/jobs/{id}/cancel` | POST | Cancel a running job |
| `/estop` | POST | Latches `/estop` and cancels active goals |
| `/confirm` | POST | Confirm a pending `WaitForUser` prompt |
| `/healthz` | GET | Health + discovered skills |
| `/openapi.json` | GET | Auto-generated OpenAPI spec |

Run:

```bash
colcon build --packages-select xarm_skills_msgs xarm_bridge
source install/setup.bash
ros2 launch xarm_bridge bridge.launch.py
# REST  → http://localhost:8000
# rosbridge WS → ws://localhost:9090
# override ports with bridge_port:= / rosbridge_port:=
```

Auth/CORS:

- `XARM_BRIDGE_API_KEY=...` — require `X-API-Key` header on mutating endpoints.
- `XARM_BRIDGE_CORS_ORIGINS=https://app.example.com,...` — restrict CORS.

## Dependencies

- `rclpy`, `std_msgs`, `rosbridge_server` (apt: `ros-humble-rosbridge-server`)
- Python: `fastapi`, `uvicorn`, `pydantic` (>= 2 — see note below)

The packages declare `python3-fastapi`, `python3-uvicorn`, `python3-pydantic`
as `exec_depend`. On Ubuntu 22.04 / Jammy the apt versions of those
satisfy import, but `python3-pydantic` apt = 1.8.2 and the bridge's
`JobResponse` model uses PEP 604 `dict | None` annotations that pydantic 1.x
rejects with `TypeError: Fields of type "<class 'types.UnionType'>" are
not supported`. Two reviewer-acceptable resolutions, happy to take either:

1. Keep the `X | None` annotations and document `pip install 'pydantic>=2'`
   (what I'm running with — works against pydantic 2.13.x).
2. Rewrite the `JobResponse` annotations to `Optional[dict]` /
   `Optional[float]` so the apt `python3-pydantic` 1.8.2 works as-is.

Happy to push (2) on top of this branch if reviewers prefer the
apt-only path; left as `X | None` for now to keep the type annotations
modern.

## Smoke test

Verified on a fresh ROS 2 Humble install (in a `ros:humble-perception`
container — `python3-fastapi`, `python3-uvicorn`, `ros-humble-rosbridge-server`
via apt; `pydantic >= 2` via pip):

- [x] `colcon build --packages-select xarm_skills_msgs xarm_bridge` — both
  packages finish; only a benign "CATKIN_INSTALL_INTO_PREFIX_ROOT not used"
  CMake warning on `xarm_skills_msgs`.
- [x] `colcon test --packages-select xarm_skills_msgs xarm_bridge` — passes
  (no unit tests defined yet).
- [x] `ros2 launch xarm_bridge bridge.launch.py` — both `bridge_node` and
  `rosbridge_websocket` start cleanly.
- [x] `curl http://localhost:8000/healthz` →
  `{"status":"ok","skills_discovered":["dispense","glue","pick_and_place","stir","transfer","wait_for_user"],"skills_count":6}`.
- [x] `curl http://localhost:8000/skills` — lists all six actions with
  their typed goal/result schemas (e.g. `Dispense` exposes
  `container_label`, `volume_ml`, `pump_rate_ml_s`, `hover_height_m`).
- [x] `rosbridge_websocket` listening on `:9090` with the topic allowlist
  applied (joint_states, TF, vision, prompts, job_feedback only).

## Out of scope

- No edits to `xarm_api`, `xarm_controller`, `xarm_description`,
  `xarm_moveit_config`, `xarm_moveit_servo`, `xarm_planner`, `xarm_gazebo`,
  `xarm_msgs`, `xarm_sdk`, `xarm_vision`, `demo` — pure addition.
- The bridge defines the *interface* for each skill; the actual action
  servers that *execute* the skills live in a downstream multi-arm/brain
  package (not part of this PR). Running `bridge.launch.py` without those
  servers gives you a working REST surface that returns jobs in `queued`
  state — useful for wiring up the front end against a stub.

## Checklist

- [x] `colcon build --packages-select xarm_skills_msgs xarm_bridge` passes
- [x] `colcon test --packages-select xarm_skills_msgs xarm_bridge` passes
- [x] `ros2 launch xarm_bridge bridge.launch.py` starts cleanly, `/healthz`
  returns ok with 6 skills, `/skills` lists all six actions
- [x] No edits to any pre-existing package in the repo
- [x] MIT-licensed (matches the repo's license)
