### PR TITLE
Support configurable poses for dual robot launches

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -302,6 +302,8 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
         # 'add_gripper_2': can separately decide whether to attach gripper for right arm，default for same value with 'add_gripper'
         # 'dof_1': can separately configure the model DOF of left arm，default to be the same DOF specified in filename.
         # 'dof_2': can separately configure the model DOF of right arm，default to be the same DOF specified in filename.
+        # 'attach_xyz_1'/'attach_rpy_1': position/orientation of the first arm，defaults to '0 0 0'.
+        # 'attach_xyz_2'/'attach_rpy_2': position/orientation of the second arm，defaults to '0 1 0'/'0 0 0'.
         
         # For xArm (xarm6 here):
         ros2 launch xarm_moveit_config dual_xarm6_moveit_fake.launch.py [add_gripper:=true]
@@ -324,6 +326,8 @@ __Reminder 4: The <hw_ns> described below is replaced with the actual one, the x
         # 'add_gripper_2': can separately decide whether to attach gripper for right arm，default for same value with 'add_gripper'
         # 'dof_1': can separately configure the model DOF of left arm，default to be the same DOF specified in filename.
         # 'dof_2': can separately configure the model DOF of right arm，default to be the same DOF specified in filename.
+        # 'attach_xyz_1'/'attach_rpy_1': position/orientation of the first arm，defaults to '0 0 0'.
+        # 'attach_xyz_2'/'attach_rpy_2': position/orientation of the second arm，defaults to '0 1 0'/'0 0 0'.
         
         # For xArm (xarm6 here):
         ros2 launch xarm_moveit_config dual_xarm6_moveit_realmove.launch.py robot_ip_1:=192.168.1.117 robot_ip_2:=192.168.1.203 [add_gripper:=true]

--- a/uf_ros_lib/Readme.md
+++ b/uf_ros_lib/Readme.md
@@ -184,6 +184,10 @@
       - __robot_type_2__: xarm/lite/uf850/xarm7_mirror
       - prefix_1: 'L_'
       - prefix_2: 'R_'
+      - attach_xyz_1: '0 0 0'
+      - attach_rpy_1: '0 0 0'
+      - attach_xyz_2: '0 1 0'
+      - attach_rpy_2: '0 0 0'
       - hw_ns: 'xarm'
       - limited: False
       - effort_control: False

--- a/uf_ros_lib/uf_ros_lib/moveit_configs_builder.py
+++ b/uf_ros_lib/uf_ros_lib/moveit_configs_builder.py
@@ -88,6 +88,10 @@ DualMoveItConfigsBuilder(
         model1300_2=False
         robot_sn_1=''
         robot_sn_2=''
+        attach_xyz_1='0 0 0'
+        attach_rpy_1='0 0 0'
+        attach_xyz_2='0 1 0'
+        attach_rpy_2='0 0 0'
         kinematics_suffix_1=''
         kinematics_suffix_2=''
         add_realsense_d435i_1=False
@@ -889,6 +893,10 @@ class DualMoveItConfigsBuilder(ParameterBuilder):
         robot_sn = get_param_str('robot_sn', '')
         robot_sn_1 = get_param_str('robot_sn_1', robot_sn)
         robot_sn_2 = get_param_str('robot_sn_2', robot_sn)
+        attach_xyz_1 = get_list_param_str('attach_xyz_1', '0 0 0')
+        attach_rpy_1 = get_list_param_str('attach_rpy_1', '0 0 0')
+        attach_xyz_2 = get_list_param_str('attach_xyz_2', '0 1 0')
+        attach_rpy_2 = get_list_param_str('attach_rpy_2', '0 0 0')
         mesh_suffix = get_param_str('mesh_suffix', 'stl')
         kinematics_suffix = get_param_str('kinematics_suffix', '')
         kinematics_suffix_1 = get_param_str('kinematics_suffix_1', kinematics_suffix)
@@ -985,6 +993,10 @@ class DualMoveItConfigsBuilder(ParameterBuilder):
             'model1300_2': model1300_2,
             'robot_sn_1': robot_sn_1,
             'robot_sn_2': robot_sn_2,
+            'attach_xyz_1': attach_xyz_1,
+            'attach_rpy_1': attach_rpy_1,
+            'attach_xyz_2': attach_xyz_2,
+            'attach_rpy_2': attach_rpy_2,
             'mesh_suffix': mesh_suffix,
             'kinematics_suffix_1': kinematics_suffix_1,
             'kinematics_suffix_2': kinematics_suffix_2,

--- a/xarm_controller/launch/_dual_ros2_control.launch.py
+++ b/xarm_controller/launch/_dual_ros2_control.launch.py
@@ -25,6 +25,10 @@ def launch_setup(context, *args, **kwargs):
     report_type_2 = LaunchConfiguration('report_type_2', default=report_type)
     prefix_1 = LaunchConfiguration('prefix_1', default='L_')
     prefix_2 = LaunchConfiguration('prefix_2', default='R_')
+    attach_xyz_1 = LaunchConfiguration('attach_xyz_1', default='"0 0 0"')
+    attach_rpy_1 = LaunchConfiguration('attach_rpy_1', default='"0 0 0"')
+    attach_xyz_2 = LaunchConfiguration('attach_xyz_2', default='"0 1 0"')
+    attach_rpy_2 = LaunchConfiguration('attach_rpy_2', default='"0 0 0"')
     dof = LaunchConfiguration('dof', default=7)
     dof_1 = LaunchConfiguration('dof_1', default=dof)
     dof_2 = LaunchConfiguration('dof_2', default=dof)
@@ -161,6 +165,10 @@ def launch_setup(context, *args, **kwargs):
                 robot_type_2=robot_type_2,
                 prefix_1=prefix_1,
                 prefix_2=prefix_2,
+                attach_xyz_1=attach_xyz_1,
+                attach_rpy_1=attach_rpy_1,
+                attach_xyz_2=attach_xyz_2,
+                attach_rpy_2=attach_rpy_2,
                 hw_ns=hw_ns,
                 limited=limited,
                 effort_control=effort_control,

--- a/xarm_description/urdf/dual_xarm_device.urdf.xacro
+++ b/xarm_description/urdf/dual_xarm_device.urdf.xacro
@@ -25,6 +25,10 @@
   <xacro:arg name="robot_sn_2" default=""/>
   <xacro:arg name="report_type_1" default="normal"/>
   <xacro:arg name="report_type_2" default="normal"/>
+  <xacro:arg name="attach_xyz_1" default="0 0 0"/>
+  <xacro:arg name="attach_rpy_1" default="0 0 0"/>
+  <xacro:arg name="attach_xyz_2" default="0 1 0"/>
+  <xacro:arg name="attach_rpy_2" default="0 0 0"/>
 
   <xacro:arg name="ros2_control_plugin" default="uf_robot_hardware/UFRobotSystemHardware"/>
   <xacro:arg name="ros2_control_params" default=""/>
@@ -81,7 +85,7 @@
     add_bio_gripper="$(arg add_bio_gripper_1)" dof="$(arg dof_1)"
     ros2_control_plugin="$(arg ros2_control_plugin)" robot_type="$(arg robot_type_1)"
     load_gazebo_plugin="false" ros2_control_params="$(arg ros2_control_params)"
-    attach_to="world" attach_xyz="0 0 0" attach_rpy="0 0 0"
+    attach_to="world" attach_xyz="$(arg attach_xyz_1)" attach_rpy="$(arg attach_rpy_1)"
     add_realsense_d435i="$(arg add_realsense_d435i_1)" 
     add_d435i_links="$(arg add_d435i_links_1)" 
     add_other_geometry="$(arg add_other_geometry_1)" 
@@ -100,7 +104,7 @@
     add_bio_gripper="$(arg add_bio_gripper_2)" dof="$(arg dof_2)"
     ros2_control_plugin="$(arg ros2_control_plugin)" robot_type="$(arg robot_type_2)"
     load_gazebo_plugin="true" ros2_control_params="$(arg ros2_control_params)"
-    attach_to="world" attach_xyz="0 1 0" attach_rpy="0 0 0" create_attach_link="false"
+    attach_to="world" attach_xyz="$(arg attach_xyz_2)" attach_rpy="$(arg attach_rpy_2)" create_attach_link="false"
     add_realsense_d435i="$(arg add_realsense_d435i_2)" 
     add_d435i_links="$(arg add_d435i_links_2)" 
     add_other_geometry="$(arg add_other_geometry_2)" 

--- a/xarm_gazebo/launch/_dual_robot_beside_table_gazebo.launch.py
+++ b/xarm_gazebo/launch/_dual_robot_beside_table_gazebo.launch.py
@@ -25,6 +25,10 @@ from uf_ros_lib.uf_robot_utils import get_xacro_content, generate_dual_ros2_cont
 def launch_setup(context, *args, **kwargs):
     prefix_1 = LaunchConfiguration('prefix_1', default='L_')
     prefix_2 = LaunchConfiguration('prefix_2', default='R_')
+    attach_xyz_1 = LaunchConfiguration('attach_xyz_1', default='"0 0 0"')
+    attach_rpy_1 = LaunchConfiguration('attach_rpy_1', default='"0 0 0"')
+    attach_xyz_2 = LaunchConfiguration('attach_xyz_2', default='"0 1 0"')
+    attach_rpy_2 = LaunchConfiguration('attach_rpy_2', default='"0 0 0"')
     dof = LaunchConfiguration('dof', default=7)
     dof_1 = LaunchConfiguration('dof_1', default=dof)
     dof_2 = LaunchConfiguration('dof_2', default=dof)
@@ -164,6 +168,10 @@ def launch_setup(context, *args, **kwargs):
                 robot_type_2=robot_type_2,
                 prefix_1=prefix_1,
                 prefix_2=prefix_2,
+                attach_xyz_1=attach_xyz_1,
+                attach_rpy_1=attach_rpy_1,
+                attach_xyz_2=attach_xyz_2,
+                attach_rpy_2=attach_rpy_2,
                 hw_ns=hw_ns,
                 limited=limited,
                 effort_control=effort_control,

--- a/xarm_moveit_config/launch/_dual_robot_moveit_common.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_common.launch.py
@@ -22,6 +22,10 @@ from launch.events import Shutdown
 def launch_setup(context, *args, **kwargs):
     prefix_1 = LaunchConfiguration('prefix_1', default='L_')
     prefix_2 = LaunchConfiguration('prefix_2', default='R_')
+    attach_xyz_1 = LaunchConfiguration('attach_xyz_1', default='"0 0 0"')
+    attach_rpy_1 = LaunchConfiguration('attach_rpy_1', default='"0 0 0"')
+    attach_xyz_2 = LaunchConfiguration('attach_xyz_2', default='"0 1 0"')
+    attach_rpy_2 = LaunchConfiguration('attach_rpy_2', default='"0 0 0"')
     dof = LaunchConfiguration('dof', default=7)
     dof_1 = LaunchConfiguration('dof_1', default=dof)
     dof_2 = LaunchConfiguration('dof_2', default=dof)
@@ -130,6 +134,10 @@ def launch_setup(context, *args, **kwargs):
         urdf_arguments={
             'prefix_1': prefix_1,
             'prefix_2': prefix_2,
+            'attach_xyz_1': attach_xyz_1,
+            'attach_rpy_1': attach_rpy_1,
+            'attach_xyz_2': attach_xyz_2,
+            'attach_rpy_2': attach_rpy_2,
             'dof_1': dof_1,
             'dof_2': dof_2,
             'robot_type_1': robot_type_1,
@@ -413,6 +421,10 @@ def launch_setup(context, *args, **kwargs):
     
     link_base_1 = '{}link_base'.format(prefix_1.perform(context))
     link_base_2 = '{}link_base'.format(prefix_2.perform(context))
+    xyz_1 = attach_xyz_1.perform(context).strip('"\'').split()
+    rpy_1 = attach_rpy_1.perform(context).strip('"\'').split()
+    xyz_2 = attach_xyz_2.perform(context).strip('"\'').split()
+    rpy_2 = attach_rpy_2.perform(context).strip('"\'').split()
 
     # Static TF
     static_tf_1 = Node(
@@ -420,7 +432,7 @@ def launch_setup(context, *args, **kwargs):
         executable='static_transform_publisher',
         name='{}static_transform_publisher'.format(prefix_1.perform(context)),
         output='screen',
-        arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', link_base_1],
+        arguments=xyz_1 + rpy_1 + ['world', link_base_1],
         parameters=[{'use_sim_time': use_sim_time}],
     )
     static_tf_2 = Node(
@@ -428,7 +440,7 @@ def launch_setup(context, *args, **kwargs):
         executable='static_transform_publisher',
         name='{}static_transform_publisher'.format(prefix_2.perform(context)),
         output='screen',
-        arguments=['0.0', '1.0', '0.0', '0.0', '0.0', '0.0', 'world', link_base_2],
+        arguments=xyz_2 + rpy_2 + ['world', link_base_2],
         parameters=[{'use_sim_time': use_sim_time}],
     )
 

--- a/xarm_moveit_config/launch/_dual_robot_moveit_common2.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_common2.launch.py
@@ -21,6 +21,10 @@ from launch.events import Shutdown
 def launch_setup(context, *args, **kwargs):
     prefix_1 = LaunchConfiguration('prefix_1', default='L_')
     prefix_2 = LaunchConfiguration('prefix_2', default='R_')
+    attach_xyz_1 = LaunchConfiguration('attach_xyz_1', default='"0 0 0"')
+    attach_rpy_1 = LaunchConfiguration('attach_rpy_1', default='"0 0 0"')
+    attach_xyz_2 = LaunchConfiguration('attach_xyz_2', default='"0 1 0"')
+    attach_rpy_2 = LaunchConfiguration('attach_rpy_2', default='"0 0 0"')
     no_gui_ctrl = LaunchConfiguration('no_gui_ctrl', default=False)
     show_rviz = LaunchConfiguration('show_rviz', default=True)
     use_sim_time = LaunchConfiguration('use_sim_time', default=False)
@@ -69,6 +73,10 @@ def launch_setup(context, *args, **kwargs):
     
     link_base_1 = '{}link_base'.format(prefix_1.perform(context))
     link_base_2 = '{}link_base'.format(prefix_2.perform(context))
+    xyz_1 = attach_xyz_1.perform(context).strip('"\'').split()
+    rpy_1 = attach_rpy_1.perform(context).strip('"\'').split()
+    xyz_2 = attach_xyz_2.perform(context).strip('"\'').split()
+    rpy_2 = attach_rpy_2.perform(context).strip('"\'').split()
 
     # Static TF
     static_tf_1 = Node(
@@ -76,7 +84,7 @@ def launch_setup(context, *args, **kwargs):
         executable='static_transform_publisher',
         name='{}static_transform_publisher'.format(prefix_1.perform(context)),
         output='screen',
-        arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', link_base_1],
+        arguments=xyz_1 + rpy_1 + ['world', link_base_1],
         parameters=[{'use_sim_time': use_sim_time}],
     )
     static_tf_2 = Node(
@@ -84,7 +92,7 @@ def launch_setup(context, *args, **kwargs):
         executable='static_transform_publisher',
         name='{}static_transform_publisher'.format(prefix_2.perform(context)),
         output='screen',
-        arguments=['0.0', '1.0', '0.0', '0.0', '0.0', '0.0', 'world', link_base_2],
+        arguments=xyz_2 + rpy_2 + ['world', link_base_2],
         parameters=[{'use_sim_time': use_sim_time}],
     )
 

--- a/xarm_moveit_config/launch/_dual_robot_moveit_fake.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_fake.launch.py
@@ -28,6 +28,10 @@ def launch_setup(context, *args, **kwargs):
     robot_type_2 = LaunchConfiguration('robot_type_2', default=robot_type)
     prefix_1 = LaunchConfiguration('prefix_1', default='L_')
     prefix_2 = LaunchConfiguration('prefix_2', default='R_')
+    attach_xyz_1 = LaunchConfiguration('attach_xyz_1', default='"0 0 0"')
+    attach_rpy_1 = LaunchConfiguration('attach_rpy_1', default='"0 0 0"')
+    attach_xyz_2 = LaunchConfiguration('attach_xyz_2', default='"0 1 0"')
+    attach_rpy_2 = LaunchConfiguration('attach_rpy_2', default='"0 0 0"')
     hw_ns = LaunchConfiguration('hw_ns', default='xarm')
     limited = LaunchConfiguration('limited', default=True)
     effort_control = LaunchConfiguration('effort_control', default=False)
@@ -138,6 +142,10 @@ def launch_setup(context, *args, **kwargs):
         model1300_2=model1300_2,
         robot_sn_1=robot_sn_1,
         robot_sn_2=robot_sn_2,
+        attach_xyz_1=attach_xyz_1,
+        attach_rpy_1=attach_rpy_1,
+        attach_xyz_2=attach_xyz_2,
+        attach_rpy_2=attach_rpy_2,
         mesh_suffix=mesh_suffix,
         kinematics_suffix_1=kinematics_suffix_1,
         kinematics_suffix_2=kinematics_suffix_2,
@@ -201,6 +209,10 @@ def launch_setup(context, *args, **kwargs):
         launch_arguments={
             'prefix_1': prefix_1,
             'prefix_2': prefix_2,
+            'attach_xyz_1': attach_xyz_1,
+            'attach_rpy_1': attach_rpy_1,
+            'attach_xyz_2': attach_xyz_2,
+            'attach_rpy_2': attach_rpy_2,
             'no_gui_ctrl': no_gui_ctrl,
             'use_sim_time': 'false',
             'moveit_config_dump': yaml.dump(moveit_config.to_dict()),

--- a/xarm_moveit_config/launch/_dual_robot_moveit_gazebo.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_gazebo.launch.py
@@ -28,6 +28,10 @@ def launch_setup(context, *args, **kwargs):
     robot_type_2 = LaunchConfiguration('robot_type_2', default=robot_type)
     prefix_1 = LaunchConfiguration('prefix_1', default='L_')
     prefix_2 = LaunchConfiguration('prefix_2', default='R_')
+    attach_xyz_1 = LaunchConfiguration('attach_xyz_1', default='"0 0 0"')
+    attach_rpy_1 = LaunchConfiguration('attach_rpy_1', default='"0 0 0"')
+    attach_xyz_2 = LaunchConfiguration('attach_xyz_2', default='"0 1 0"')
+    attach_rpy_2 = LaunchConfiguration('attach_rpy_2', default='"0 0 0"')
     hw_ns = LaunchConfiguration('hw_ns', default='xarm')
     limited = LaunchConfiguration('limited', default=True)
     effort_control = LaunchConfiguration('effort_control', default=False)
@@ -141,6 +145,10 @@ def launch_setup(context, *args, **kwargs):
         model1300_2=model1300_2,
         robot_sn_1=robot_sn_1,
         robot_sn_2=robot_sn_2,
+        attach_xyz_1=attach_xyz_1,
+        attach_rpy_1=attach_rpy_1,
+        attach_xyz_2=attach_xyz_2,
+        attach_rpy_2=attach_rpy_2,
         mesh_suffix=mesh_suffix,
         kinematics_suffix_1=kinematics_suffix_1,
         kinematics_suffix_2=kinematics_suffix_2,
@@ -193,6 +201,10 @@ def launch_setup(context, *args, **kwargs):
         launch_arguments={
             'prefix_1': prefix_1,
             'prefix_2': prefix_2,
+            'attach_xyz_1': attach_xyz_1,
+            'attach_rpy_1': attach_rpy_1,
+            'attach_xyz_2': attach_xyz_2,
+            'attach_rpy_2': attach_rpy_2,
             'no_gui_ctrl': no_gui_ctrl,
             'show_rviz': 'false',
             'use_sim_time': 'true',
@@ -211,6 +223,10 @@ def launch_setup(context, *args, **kwargs):
             'robot_type_2': robot_type_2,
             'prefix_1': prefix_1,
             'prefix_2': prefix_2,
+            'attach_xyz_1': attach_xyz_1,
+            'attach_rpy_1': attach_rpy_1,
+            'attach_xyz_2': attach_xyz_2,
+            'attach_rpy_2': attach_rpy_2,
             'moveit_config_dump': moveit_config_dump,
             'load_controller': 'true',
             'show_rviz': 'true',

--- a/xarm_moveit_config/launch/_dual_robot_moveit_realmove.launch.py
+++ b/xarm_moveit_config/launch/_dual_robot_moveit_realmove.launch.py
@@ -39,6 +39,10 @@ def launch_setup(context, *args, **kwargs):
     robot_type_2 = LaunchConfiguration('robot_type_2', default=robot_type)
     prefix_1 = LaunchConfiguration('prefix_1', default='L_')
     prefix_2 = LaunchConfiguration('prefix_2', default='R_')
+    attach_xyz_1 = LaunchConfiguration('attach_xyz_1', default='"0 0 0"')
+    attach_rpy_1 = LaunchConfiguration('attach_rpy_1', default='"0 0 0"')
+    attach_xyz_2 = LaunchConfiguration('attach_xyz_2', default='"0 1 0"')
+    attach_rpy_2 = LaunchConfiguration('attach_rpy_2', default='"0 0 0"')
     hw_ns = LaunchConfiguration('hw_ns', default='xarm')
     limited = LaunchConfiguration('limited', default=True)
     effort_control = LaunchConfiguration('effort_control', default=False)
@@ -158,6 +162,10 @@ def launch_setup(context, *args, **kwargs):
         model1300_2=model1300_2,
         robot_sn_1=robot_sn_1,
         robot_sn_2=robot_sn_2,
+        attach_xyz_1=attach_xyz_1,
+        attach_rpy_1=attach_rpy_1,
+        attach_xyz_2=attach_xyz_2,
+        attach_rpy_2=attach_rpy_2,
         mesh_suffix=mesh_suffix,
         kinematics_suffix_1=kinematics_suffix_1,
         kinematics_suffix_2=kinematics_suffix_2,
@@ -221,6 +229,10 @@ def launch_setup(context, *args, **kwargs):
         launch_arguments={
             'prefix_1': prefix_1,
             'prefix_2': prefix_2,
+            'attach_xyz_1': attach_xyz_1,
+            'attach_rpy_1': attach_rpy_1,
+            'attach_xyz_2': attach_xyz_2,
+            'attach_rpy_2': attach_rpy_2,
             'no_gui_ctrl': no_gui_ctrl,
             'use_sim_time': 'false',
             'moveit_config_dump': yaml.dump(moveit_config.to_dict()),


### PR DESCRIPTION
## Summary

- expose independent `attach_xyz_1` / `attach_rpy_1` and `attach_xyz_2` / `attach_rpy_2` parameters for dual-arm setups
- propagate the poses consistently through the dual URDF, MoveIt configuration builder, Gazebo, ros2_control, and static TF publishers
- preserve the existing default layout: arm 1 at `0 0 0`, arm 2 at `0 1 0`, with zero rotation
- document the new builder and launch parameters

## Why

The relative dual-arm poses were hard-coded in `dual_xarm_device.urdf.xacro` and duplicated in the static TF publishers. Users therefore had to edit source files to model a different installation, and changing only one location could leave the URDF and TF tree inconsistent.

This implements the configurable dual-arm pose proposed by @srinath2468 in #167. I could not find an existing upstream PR for the issue, so I kept the repository's `_1` / `_2` naming convention and credited the original proposal here.

## User impact

Dual simulated and real-arm launch paths can now receive each robot's XYZ and RPY pose externally without modifying package sources. Existing launch commands retain the same geometry by default.

## Validation

- compiled all changed Python files with `python3 -m py_compile`
- parsed `dual_xarm_device.urdf.xacro` as XML
- ran static propagation assertions for all four parameters across the builder and launch layers
- ran `git diff --check`

A full ROS 2 / Gazebo runtime is not installed in the development environment, so maintainers will still need to run the launch-level simulation test.

Fixes #167
