### PR TITLE
fix(xarm_gazebo): update rosdep keys for ROS Jazzy compatibility

### DIFF
--- a/xarm_gazebo/package.xml
+++ b/xarm_gazebo/package.xml
@@ -10,8 +10,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>gz-sim8</depend>
-  <depend>sdformat14</depend>
+  <depend>ros_gz</depend>
+  <depend>gz_sim_vendor</depend>
+  <depend>sdformat_urdf</depend>
   <depend>xarm_description</depend>
   <depend>xarm_controller</depend>
 


### PR DESCRIPTION
### Summary
Fixes `rosdep install` failure when building `xarm_gazebo` on ROS 2 Jazzy / Ubuntu 24.04 (Noble).

### Problem
Running `rosdep install --from-paths . --ignore-src --rosdistro jazzy` fails with:
- `ERROR: Cannot locate rosdep definition for [sdformat14]`
- `ERROR: Cannot locate rosdep definition for [gz-sim8]`

This occurs because raw APT package keys (`sdformat14`, `gz-sim8`) are not defined in `rosdep/base.yaml` or '[rosdistro](https://github.com/ros/rosdistro/tree/master)/[jazzy](https://github.com/ros/rosdistro/tree/master/jazzy)
/distribution.yaml' for ROS Jazzy.

### Solution
Updated `package.xml` dependencies to use official ROS 2 Jazzy vendor wrapper keys (`ros_gz`, `gz_sim_vendor`, `sdformat_urdf`), allowing `rosdep` to resolve system dependencies cleanly without requiring `--skip-keys`.

### Test Matrix
- **OS:** Ubuntu 24.04 LTS (Noble)
- **ROS Version:** ROS 2 Jazzy Jalisco
- **Verification:** `rosdep install` succeeds without errors on a clean workspace.